### PR TITLE
Use commitlint and husky for commit message linting

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,14 @@
     "type": "git",
     "url": "git@github.com:kappnav/ui.git"
   },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }  
+  },
+  "rules": {
+    "header-max-length": [0, "always", 72]
+  },
   "dependencies": {
     "assets-webpack-plugin": "^3.9.6",
     "babel-core": "^6.26.0",
@@ -68,6 +76,8 @@
     "reselect": "^3.0.1"
   },
   "devDependencies": {
+    "@commitlint/cli": "^8.1.0",
+    "@commitlint/config-conventional": "^8.1.0",
     "@hapi/hawk": "^7.1.0",
     "autoprefixer": "^8.6.5",
     "babel-eslint": "^8.2.3",
@@ -92,6 +102,7 @@
     "git-revision-webpack-plugin": "^2.5.1",
     "hamburgers": "^0.9.1",
     "handlebars-loader": "^1.6.0",
+    "husky": "^3.0.3",
     "loadable-components": "^1.4.0",
     "node-gyp": "^4.0.0",
     "node-sass": "^4.9.4",


### PR DESCRIPTION
Use `commitlint` to enforce rules on commit messages.
Use `husky` to to run `commitlint` on every `git commit` command.

For more information on `commitlint`, see https://github.com/conventional-changelog/commitlint