### PR TITLE
fix: Command actions page hang

### DIFF
--- a/src-web/components/kappnav/modals/ActionMessageModal.js
+++ b/src-web/components/kappnav/modals/ActionMessageModal.js
@@ -80,8 +80,8 @@ class ActionMessageModal extends React.PureComponent {
           aria-label={'Label'}
           open={open}>
           <ModalHeader buttonOnClick={handleClose}>
-            <h4 className="bx--modal-header__label">{result.metadata.labels['app-nav-job-component-name']}</h4>
-            <h2 className="bx--modal-header__heading">{result.metadata.annotations['app-nav-job-action-text']}</h2>
+            <h4 className="bx--modal-header__label">{result.metadata.labels['kappnav-job-component-name']}</h4>
+            <h2 className="bx--modal-header__heading">{result.metadata.annotations['kappnav-job-action-text']}</h2>
           </ModalHeader>
           <ModalBody>
             {msgs.get('job.success')}


### PR DESCRIPTION
Depends on kappnav/operator#15
Fixes #22
Fixes #23 

- `app-nav*` is no longer used.  Change `app-nav*` to `kappnav-*`

- On minishift, there is no OKD console page to view K8 jobs; therefore,
the configmap `kappnav.actions.job` will  not have `url-actions`.  We
need to change the code to stop assuming `url-actions` will always be
present in the `kappnav.actions.job` configmap.  When the `url-actions`
is missing, use plain text instead of a link.

#### OKD with fix
![image](https://user-images.githubusercontent.com/31117513/64879578-e969d900-d61b-11e9-8612-f18fcd38fab2.png)

#### minishift with fix (note no clickable job name)
![image](https://user-images.githubusercontent.com/31117513/64880088-fe933780-d61c-11e9-9008-90f345bfbf6e.png)
