### PR TITLE
fix: Command actions page hang (v0.1.1)

### DIFF
--- a/src-web/components/kappnav/modals/ActionMessageModal.js
+++ b/src-web/components/kappnav/modals/ActionMessageModal.js
@@ -80,8 +80,8 @@ class ActionMessageModal extends React.PureComponent {
           aria-label={'Label'}
           open={open}>
           <ModalHeader buttonOnClick={handleClose}>
-            <h4 className="bx--modal-header__label">{result.metadata.labels['app-nav-job-component-name']}</h4>
-            <h2 className="bx--modal-header__heading">{result.metadata.annotations['app-nav-job-action-text']}</h2>
+            <h4 className="bx--modal-header__label">{result.metadata.labels['kappnav-job-component-name']}</h4>
+            <h2 className="bx--modal-header__heading">{result.metadata.annotations['kappnav-job-action-text']}</h2>
           </ModalHeader>
           <ModalBody>
             {msgs.get('job.success')}


### PR DESCRIPTION
Related to #30.  This fix also needs to be in `v0.1.1`

- `app-nav*` is no longer used.  Change `app-nav*` to `kappnav-*`

- On minishift, there is no OKD console page to view K8 jobs; therefore,
the configmap `kappnav.actions.job` will  not have `url-actions`.  We
need to change the code to stop assuming `url-actions` will always be
present in the `kappnav.actions.job` configmap.  When the `url-actions`
is missing, use plain text instead of a link.