### PR TITLE
Fixing or suppressing errors found by eslinter

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-    "presets" : ["react"]
+    "presets" : ["es2015", "react", "stage-0"]
 }

--- a/app.js
+++ b/app.js
@@ -19,7 +19,6 @@
 const express = require('express'),
       config = require('./config/config-defaults.json'),
       path = require('path'),
-      fs = require('fs'),
       moment = require('moment'),
       i18n = require('node-i18n-util'),
       app = express(),
@@ -29,9 +28,7 @@ var log4js = require('log4js'),
     consolidate = require('consolidate'),
     cookieParser = require('cookie-parser'),
     csurf = require('csurf'),
-    proxy = require('http-proxy-middleware'),
-    https = require('https')
-
+    proxy = require('http-proxy-middleware')
 const logger = log4js.getLogger('server')
 var log4js_config = process.env.LOG4JS_CONFIG ? JSON.parse(process.env.LOG4JS_CONFIG) : undefined
 log4js.configure(log4js_config || 'config/log4js.json')
@@ -56,7 +53,7 @@ var exclude = function(path) {
 }
 
 //Redirect / to /kappnav-ui, (because the auth proxy sidecar redirects to /)
-app.all('/', (req, res, next) => {
+app.all('/', (req, res) => {
   res.redirect(CONTEXT_PATH)
 })
 

--- a/lib/shared/dust-helpers.js
+++ b/lib/shared/dust-helpers.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  *****************************************************************/
- 
+
 'use strict'
 
 var dust = require('dustjs-helpers'),

--- a/package.json
+++ b/package.json
@@ -25,6 +25,14 @@
     "type": "git",
     "url": "git@github.com:kappnav/ui.git"
   },
+  "babel": {
+    "presets": [
+      "react-app"
+    ]
+  },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
   "dependencies": {
     "assets-webpack-plugin": "^3.9.6",
     "babel-core": "^6.26.0",
@@ -33,9 +41,12 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
+    "rimraf": "^2.6.1",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-react-app": "^3.1.0",
     "babel-preset-stage-2": "^6.24.1",
     "babel-register": "^6.24.1",
+    "babel-runtime": "6.26.0",
     "body-parser": "^1.17.2",
     "carbon-addons-cloud": "3.x",
     "carbon-addons-cloud-react": "1.x",
@@ -61,20 +72,29 @@
     "postcss-easy-import": "^3.0.0",
     "postcss-loader": "^2.1.0",
     "react-ace": "^5.2.0",
+    "react-redux": "^5.0.6",
     "react-router-dom": "^4.3.1",
     "react-transition-group": "^2.8.0",
+    "redux": "^3.7.2",
+    "redux-devtools-extension": "^2.13.2",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "requestretry": "^1.13.0",
-    "reselect": "^3.0.1"
+    "reselect": "^3.0.1",
+    "util": "^0.12.1"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
     "@hapi/hawk": "^7.1.0",
     "autoprefixer": "^8.6.5",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-polyfill": "^6.26.0",
+    "babel-preset-stage-0": "^6.24.1",
     "bulma": "^0.5.3",
     "chai": "^4.0.0",
     "classnames": "^2.2.5",

--- a/server/routers/health.js
+++ b/server/routers/health.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,16 +16,17 @@
  *
  *****************************************************************/
 
-var express = require('express');
+var express = require('express')
 
 module.exports = function(app) {
-  var router = express.Router();
+  var router = express.Router()
 
-  router.get('/', function (req, res, next) {
-    res.json({status: 'UP'});
-  });
+  // eslint-disable-next-line no-unused-vars
+  router.get('/', (req, res, next) => {
+    res.json({status: 'UP'})
+  })
 
-  app.use("/health", router);
+  app.use('/health', router)
 }
 
 

--- a/server/routers/index.js
+++ b/server/routers/index.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,11 +15,11 @@
  * limitations under the License.
  *
  *****************************************************************/
- 
-module.exports = function(app){
-  
-    require('./public')(app);
-  
-    require('./health')(app);
 
-};  
+module.exports = function(app){
+
+  require('./public')(app)
+
+  require('./health')(app)
+
+}  

--- a/server/routers/public.js
+++ b/server/routers/public.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,10 +16,10 @@
  *
  *****************************************************************/
 
-var express = require('express');
+var express = require('express')
 
 module.exports = function(app){
-  var router = express.Router();
-  router.use(express.static(process.cwd() + '/public'));
-  app.use(router);
+  var router = express.Router()
+  router.use(express.static(process.cwd() + '/public'))
+  app.use(router)
 }

--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -118,13 +118,16 @@ export const transform = (resource, key) => {
     return key.transformFunction(resource)
   } else if (key.type === 'tag') {
     var data = key.getData(resource)
+    // eslint-disable-next-line react/no-array-index-key
     return data ? data.map((tagText, index) => <Tag key={`tag-${index}`} style={{display: 'inline-block'}} type={'beta'} title={tagText.title}>{tagText.value ? `${tagText.name}:${tagText.value}` : tagText.name}</Tag>) : '-'
   } else if (key.type === 'expression') {
-    var data = key.getData(resource)
-    return data ? data.map((tagText, index) =><span className="bx--tag bx--tag--beta" title={tagText.title} style={{display: 'inline-block'}}>{tagText.name}<div className="expression">{tagText.operator}</div>{tagText.value}</span>) : '-'
+    var exp = key.getData(resource)
+    // eslint-disable-next-line react/no-array-index-key
+    return exp ? exp.map((tagText, index) =><span key={`resource-${index}`} className="bx--tag bx--tag--beta" title={tagText.title} style={{display: 'inline-block'}}>{tagText.name}<div className="expression">{tagText.operator}</div>{tagText.value}</span>) : '-'
   } else if (key.type === 'links') {
-    var data = key.getData(resource)
-    return data ? data.map((linkInfo, index) => <a style={{display: 'block'}} key={`link-${index}`} href={linkInfo.url} target="_blank" rel="noopener noreferrer" title={linkInfo.description}>{linkInfo.description}</a>) : '-'
+    var links = key.getData(resource)
+    // eslint-disable-next-line react/no-array-index-key
+    return links ? links.map((linkInfo, index) => <a style={{display: 'block'}} key={`link-${index}`} href={linkInfo.url} target="_blank" rel="noopener noreferrer" title={linkInfo.description}>{linkInfo.description}</a>) : '-'
   } else {
     return (value || value === 0) ? value : '-'
   }
@@ -147,21 +150,21 @@ var defaultTimestampKey = 'metadata.creationTimestamp'
 
 export const getAgeDifference = (createdTime) => {
   const difference = moment().diff(createdTime),
-    diffDuration = moment.duration(difference),
-    days = diffDuration.days(),
-    hours = diffDuration.hours(),
-    minutes = diffDuration.minutes()
+        diffDuration = moment.duration(difference),
+        days = diffDuration.days(),
+        hours = diffDuration.hours(),
+        minutes = diffDuration.minutes()
   return {'difference': difference, 'diffDuration': diffDuration, 'days': days, 'hours': hours, 'minutes' : minutes}
 }
 
 export const getCreationTime = (item, timestampKey) => {
   const key = timestampKey ? timestampKey : defaultTimestampKey
   const createdTime = lodash.get(item, key)
-  return createdTime;
+  return createdTime
 }
 
 export const getAge = (item, timestampKey) => {
-  const createdTime = getCreationTime(item, timestampKey);
+  const createdTime = getCreationTime(item, timestampKey)
   if (createdTime) {
     const diff = getAgeDifference(createdTime),
           days = diff.days,
@@ -182,10 +185,10 @@ export const getAge = (item, timestampKey) => {
 export const openModal = (operation, resource, application, applicationNamespace, cmd, cmdInput) => {
   const resourceType = resource.kind.toLowerCase()
   if(resourceType === 'job' && operation === 'remove') {
-    // The delete job logic is very different from the other 
+    // The delete job logic is very different from the other
     window.secondaryHeader.showRemoveResourceModal(
-      true, 
-      { primaryBtn: 'modal.button.' + operation, heading: 'modal.' + operation + '.heading' }, 
+      true,
+      { primaryBtn: 'modal.button.' + operation, heading: 'modal.' + operation + '.heading' },
       resource,
       '/kappnav/resource/command/' + encodeURIComponent(resource.metadata.name)
     )
@@ -199,7 +202,7 @@ export const openModal = (operation, resource, application, applicationNamespace
     if(application) {
       url = '/kappnav/resource/' + encodeURIComponent(application)+'/' + encodeURIComponent(resource.metadata.name)+'/'+resource.kind+'/execute/command/'+encodeURIComponent(cmd.name)+'?namespace='+encodeURIComponent(resource.metadata.namespace)+'&application-namespace='+applicationNamespace
     }
-      
+
     var input = undefined
     if(cmdInput && cmd[CONFIG_CONSTANTS.REQUIRES_INPUT]) {
       input = cmdInput[cmd[CONFIG_CONSTANTS.REQUIRES_INPUT]]
@@ -208,7 +211,7 @@ export const openModal = (operation, resource, application, applicationNamespace
     window.secondaryHeader.showActionResourceModal(true, {
       primaryBtn: 'modal.button.submit',
       heading: cmd.description
-    }, resource, url, input, cmd)  
+    }, resource, url, input, cmd)
   } else {
     window.secondaryHeader.showRemoveResourceModal(true, {
       primaryBtn: 'modal.button.'+operation,
@@ -232,12 +235,13 @@ export const performUrlAction = (urlPattern, openWindow, kind, name, namespace, 
         let url = result.action
 
         try {
-          let parsedURL = new URL(result.action)
+          const parsedURL = new URL(result.action)
           if(parsedURL && parsedURL.searchParams){
-            let searchParams = parsedURL.searchParams.entries()
+            const searchParams = parsedURL.searchParams.entries()
             let newURL = parsedURL.origin+parsedURL.pathname+parsedURL.hash
             //URL encode search params
             let first = true
+            // eslint-disable-next-line prefer-const
             for (let [key, value] of searchParams) {
               if (first === true) {
                 newURL = newURL + '?'
@@ -285,9 +289,9 @@ export const getHoverOverTextForStatus = (annotations) => {
   if(! annotations) {
     return ''
   }
-  let hoverOverNLS = annotations['kappnav.status.flyover.nls']
+  const hoverOverNLS = annotations['kappnav.status.flyover.nls']
   if(hoverOverNLS) {
-    let flyover = JSON.parse(hoverOverNLS)
+    const flyover = JSON.parse(hoverOverNLS)
     if(! Array.isArray(flyover)) {
       // Expect this to be a string like "unknown"
       return msgs.get(flyover.toLowerCase())
@@ -295,19 +299,19 @@ export const getHoverOverTextForStatus = (annotations) => {
 
     // splice will return index 0 and delete the element from the array
     // details array should be left with only arguments for the PII message e.g. {0} {1} ...
-    let indexToRemove = 0;
-    let howManyToRemoveFromArray = 1;
-    let msgKey = flyover.splice(indexToRemove, howManyToRemoveFromArray)
+    const indexToRemove = 0
+    const howManyToRemoveFromArray = 1
+    const msgKey = flyover.splice(indexToRemove, howManyToRemoveFromArray)
     return msgs.get(msgKey, flyover)
   }
-  let hoverOver_notNLS = annotations['kappnav.status.flyover']
+  const hoverOver_notNLS = annotations['kappnav.status.flyover']
   if(hoverOver_notNLS) {
     return hoverOver_notNLS
   }
   return ''
 }
 
-export const getStatus = (metadata, appNavConfigData) => { 
+export const getStatus = (metadata, appNavConfigData) => {
   const statusColorMapping = appNavConfigData && appNavConfigData.statuColorMapping
   const statusPrecedence = appNavConfigData && appNavConfigData.statusPrecedence ? appNavConfigData && appNavConfigData.statusPrecedence : []
   const statusUnknown = appNavConfigData && appNavConfigData.statusUnknown
@@ -321,10 +325,10 @@ export const getStatus = (metadata, appNavConfigData) => {
   let statusText = ''
   let sortTitle = ''
 
-  const name = metadata && metadata.name;
+  const name = metadata && metadata.name
   const value = annotations && annotations['kappnav.status.value'] ? annotations['kappnav.status.value'] : statusUnknown
   const sortIndex = statusPrecedence.findIndex(val => val === value)
-  
+
   if(statusColorMapping && value) {
     statusText = msgs.get(value.toLowerCase())
     const colorKey = statusColorMapping.values && statusColorMapping.values[value]
@@ -338,19 +342,19 @@ export const getStatus = (metadata, appNavConfigData) => {
   }
 
   return {
-    statusColor: statusColor, 
-    borderColor: STATUS_COLORS.BORDER_COLOR, 
-    statusMessage: statusMessage, 
-    statusText: statusText, 
+    statusColor: statusColor,
+    borderColor: STATUS_COLORS.BORDER_COLOR,
+    statusMessage: statusMessage,
+    statusText: statusText,
     sortTitle: sortTitle}
 }
 
 export const buildStatusHtml = (statusObj) => {
   return (
     <div className='statusCell' data-sorttitle={statusObj.sortTitle}>
-      <span className="bx--detail-page-header-status-icon" 
-            title={statusObj.statusMessage} 
-            style={{backgroundColor: statusObj.statusColor, borderColor: statusObj.borderColor}}>
+      <span className="bx--detail-page-header-status-icon"
+        title={statusObj.statusMessage}
+        style={{backgroundColor: statusObj.statusColor, borderColor: statusObj.borderColor}}>
       </span>
       <span className="bx--detail-page-header-status-text">{statusObj.statusText}</span>
     </div>
@@ -358,19 +362,19 @@ export const buildStatusHtml = (statusObj) => {
 }
 
 export const validateUrl = (url) => {
-  // Parse the user provided URL.  This is crude way to prevent XSS by 
+  // Parse the user provided URL.  This is crude way to prevent XSS by
   // sanity checking the user's input is actually a URL
 
-  var result = {href: "", text: ""}
+  var result = {href: '', text: ''}
   try {
     if(url && url.trim()) { // check for empty or non-existing string
-      let temp = new URL(url)
+      const temp = new URL(url)
       result.href = temp.href
       result.text = temp.href
     }
   } catch(err) {
-    // If URL cannot parse the string, that must mean the user input 
-    // is not in a URL format.  Let's be on the safeside and not display 
+    // If URL cannot parse the string, that must mean the user input
+    // is not in a URL format.  Let's be on the safeside and not display
     // the user's input (XSS) and display a reason why the URL is not shown
     result.text = msgs.get('description.title.urlError')
   }
@@ -399,58 +403,58 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
   var hasCmdActions = cmdActions && cmdActions.length && cmdActions.length>0
 
   if(hasStaticActions || hasUrlActions || hasCmdActions) {
-      var menu = <OverflowMenu floatingMenu flipped iconDescription={msgs.get('svg.description.overflowMenu')}>
-        {(() => {
-          if(hasStaticActions) {
-            return staticResourceData.actions.map((action, staticindex) => (
-              <OverflowMenuItem key={itemId + action}
-                primaryFocus={staticindex === 0}
-                itemText={msgs.get('table.actions.'+action)}
-                onClick={openModal.bind(this, action, cloneData)}
-                onFocus={(e) => {e.target.title = msgs.get('table.actions.'+action)}}
-                onMouseEnter={(e) => {e.target.title = msgs.get('table.actions.'+action)}} />
-            ))
-          }
-        })()}
-        {(() => {
-          if(urlActions) {
-            urlActions.forEach((action) => { //try to cache the links ahead of time
-              var kind = componentData && componentData.kind
-              var namespace = componentData && componentData.metadata && componentData.metadata.namespace
-              var name = componentData && componentData.metadata && componentData.metadata.name
-              performUrlAction(action['url-pattern'], action['open-window'], kind, name, namespace, undefined, false)
-            })
+    var menu = <OverflowMenu floatingMenu flipped iconDescription={msgs.get('svg.description.overflowMenu')}>
+      {(() => {
+        if(hasStaticActions) {
+          return staticResourceData.actions.map((action, staticindex) => (
+            <OverflowMenuItem key={itemId + action}
+              primaryFocus={staticindex === 0}
+              itemText={msgs.get('table.actions.'+action)}
+              onClick={openModal.bind(this, action, cloneData)}
+              onFocus={(e) => {e.target.title = msgs.get('table.actions.'+action)}}
+              onMouseEnter={(e) => {e.target.title = msgs.get('table.actions.'+action)}} />
+          ))
+        }
+      })()}
+      {(() => {
+        if(urlActions) {
+          urlActions.forEach((action) => { //try to cache the links ahead of time
+            var kind = componentData && componentData.kind
+            var namespace = componentData && componentData.metadata && componentData.metadata.namespace
+            var name = componentData && componentData.metadata && componentData.metadata.name
+            performUrlAction(action['url-pattern'], action['open-window'], kind, name, namespace, undefined, false)
+          })
 
-            return urlActions.map((action, urlindex) => {
-              let actionLabel = action['text.nls'] ? msgs.get(action['text.nls']) : action.text
-              let actionDesc = action['description.nls'] ? msgs.get(action['description.nls']) : action.description
-              return <OverflowMenuItem key={action.name}
-                primaryFocus={urlindex === 0 && !hasStaticActions}
-                itemText={actionLabel}
-                onClick={performUrlAction.bind(this, action['url-pattern'], action['open-window'], componentData && componentData.kind, componentData && componentData.metadata && componentData.metadata.name, componentData && componentData.metadata && componentData.metadata.namespace, undefined, true)}
-                onFocus={(e) => {
-                  if(actionDesc){ e.target.title = actionDesc }
-                }}
-                onMouseEnter={(e) => {
-                  if(actionDesc){ e.target.title = actionDesc }
-                }} />
-            })
-          }
-        })()}
-        {(() => {
-          if(cmdActions) {
-            return cmdActions.map((action, cmdindex) => (
-              <OverflowMenuItem key={action.name}
-                primaryFocus={cmdindex === 0 && !hasUrlActions && !hasStaticActions}
-                itemText={action.text ? action.text : action.description ? action.description : action.name}
-                onClick={openModal.bind(this, "action", cloneData, applicationName, applicationNamespace, action, cmdInputs)}
-                onFocus={(e) => {if(action.description) e.target.title = action.description}}
-                onMouseEnter={(e) => {if(action.description) e.target.title = action.description}} />
-            ))
-          }
-        })()}
-      </OverflowMenu>
+          return urlActions.map((action, urlindex) => {
+            const actionLabel = action['text.nls'] ? msgs.get(action['text.nls']) : action.text
+            const actionDesc = action['description.nls'] ? msgs.get(action['description.nls']) : action.description
+            return <OverflowMenuItem key={action.name}
+              primaryFocus={urlindex === 0 && !hasStaticActions}
+              itemText={actionLabel}
+              onClick={performUrlAction.bind(this, action['url-pattern'], action['open-window'], componentData && componentData.kind, componentData && componentData.metadata && componentData.metadata.name, componentData && componentData.metadata && componentData.metadata.namespace, undefined, true)}
+              onFocus={(e) => {
+                if(actionDesc){ e.target.title = actionDesc }
+              }}
+              onMouseEnter={(e) => {
+                if(actionDesc){ e.target.title = actionDesc }
+              }} />
+          })
+        }
+      })()}
+      {(() => {
+        if(cmdActions) {
+          return cmdActions.map((action, cmdindex) => (
+            <OverflowMenuItem key={action.name}
+              primaryFocus={cmdindex === 0 && !hasUrlActions && !hasStaticActions}
+              itemText={action.text ? action.text : action.description ? action.description : action.name}
+              onClick={openModal.bind(this, 'action', cloneData, applicationName, applicationNamespace, action, cmdInputs)}
+              onFocus={(e) => {if(action.description) e.target.title = action.description}}
+              onMouseEnter={(e) => {if(action.description) e.target.title = action.description}} />
+          ))
+        }
+      })()}
+    </OverflowMenu>
 
-      return menu
+    return menu
   }
 }

--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -118,16 +118,13 @@ export const transform = (resource, key) => {
     return key.transformFunction(resource)
   } else if (key.type === 'tag') {
     var data = key.getData(resource)
-    // eslint-disable-next-line react/no-array-index-key
-    return data ? data.map((tagText, index) => <Tag key={`tag-${index}`} style={{display: 'inline-block'}} type={'beta'} title={tagText.title}>{tagText.value ? `${tagText.name}:${tagText.value}` : tagText.name}</Tag>) : '-'
+    return data ? data.map((tagText) => <Tag key={`tag-${tagText}`} style={{display: 'inline-block'}} type={'beta'} title={tagText.title}>{tagText.value ? `${tagText.name}:${tagText.value}` : tagText.name}</Tag>) : '-'
   } else if (key.type === 'expression') {
     var exp = key.getData(resource)
-    // eslint-disable-next-line react/no-array-index-key
-    return exp ? exp.map((tagText, index) =><span key={`resource-${index}`} className="bx--tag bx--tag--beta" title={tagText.title} style={{display: 'inline-block'}}>{tagText.name}<div className="expression">{tagText.operator}</div>{tagText.value}</span>) : '-'
+    return exp ? exp.map((tagText) =><span key={`resource-${tagText.id}`} className="bx--tag bx--tag--beta" title={tagText.title} style={{display: 'inline-block'}}>{tagText.name}<div className="expression">{tagText.operator}</div>{tagText.value}</span>) : '-'
   } else if (key.type === 'links') {
     var links = key.getData(resource)
-    // eslint-disable-next-line react/no-array-index-key
-    return links ? links.map((linkInfo, index) => <a style={{display: 'block'}} key={`link-${index}`} href={linkInfo.url} target="_blank" rel="noopener noreferrer" title={linkInfo.description}>{linkInfo.description}</a>) : '-'
+    return links ? links.map((linkInfo) => <a style={{display: 'block'}} key={`link-${linkInfo.id}`} href={linkInfo.url} target="_blank" rel="noopener noreferrer" title={linkInfo.description}>{linkInfo.description}</a>) : '-'
   } else {
     return (value || value === 0) ? value : '-'
   }

--- a/src-web/actions/constants.js
+++ b/src-web/actions/constants.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src-web/components/LeftNav.js
+++ b/src-web/components/LeftNav.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,13 +28,13 @@ class LeftNav extends React.Component {
 
   render() {
     return (
-      <CSSTransition classNames='transition' in={this.props.open} timeout={300} 
-          mountOnEnter={true} unmountOnExit={true} 
-          onEntered={() => this.leftNav.focus()}>
+      <CSSTransition classNames='transition' in={this.props.open} timeout={300}
+        mountOnEnter={true} unmountOnExit={true}
+        onEntered={() => this.leftNav.focus()}>
 
         {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
         <nav ref={nav => this.leftNav = nav} id='left-nav' tabIndex='-1'
-            className='left-nav' aria-label={msgs.get('header.menu.bar.label')}>
+          className='left-nav' aria-label={msgs.get('header.menu.bar.label')}>
 
           { this.renderRoutes() }
 
@@ -52,18 +52,20 @@ class LeftNav extends React.Component {
           <a role='menuitem' href="/kappnav-ui/applications" title={msgs.get('page.applicationView.title')}>{msgs.get('page.applicationView.title')}</a>
         </li>
         <li className="left-nav-item primary-nav-item">
-        <a role='menuitem' href="/kappnav-ui/jobs" title={msgs.get('page.jobsView.title')}>{msgs.get('page.jobsView.title')}</a>
+          <a role='menuitem' href="/kappnav-ui/jobs" title={msgs.get('page.jobsView.title')}>{msgs.get('page.jobsView.title')}</a>
         </li>
       </ul>
     )
   } // end of renderRoutes(...)
 
-
-
 }
 
 LeftNav.contextTypes = {
-  locale: PropTypes.string
+  locale: PropTypes.string,
+}
+
+LeftNav.propTypes = {
+  open: PropTypes.bool
 }
 
 export default LeftNav

--- a/src-web/components/ViewContainer.jsx
+++ b/src-web/components/ViewContainer.jsx
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,67 +16,74 @@
  *
  *****************************************************************/
 
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import { fetchLoadingNamespaces, fetchLoadingSecrets, fetchLoadingAppNavConfigMaps } from '../reducers/BaseServiceReducer';
-import AppView from './kappnav/AppView.jsx';
-import ComponentView from './kappnav/ComponentView.jsx';
-import DetailView from './kappnav/DetailView.jsx';
-import JobView from './kappnav/JobView.jsx';
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import { fetchLoadingNamespaces, fetchLoadingSecrets, fetchLoadingAppNavConfigMaps } from '../reducers/BaseServiceReducer'
+import AppView from './kappnav/AppView.jsx'
+import ComponentView from './kappnav/ComponentView.jsx'
+import DetailView from './kappnav/DetailView.jsx'
+import JobView from './kappnav/JobView.jsx'
+import PropTypes from 'prop-types'
 
 class ViewContainer extends Component {
 
-    componentWillMount = () => {
-        if (this.props.baseInfo.namespaces.length === 0) {
-            this.props.fetchLoadingNamespaces();
-        }
+    UNSAFE_componentWillMount = () => {
+      if (this.props.baseInfo.namespaces.length === 0) {
+        this.props.fetchLoadingNamespaces()
+      }
 
-        if (this.props.baseInfo.secrets.length === 0) {
-            console.log("I am here")
-            this.props.fetchLoadingSecrets();
-        }
+      if (this.props.baseInfo.secrets.length === 0) {
+        this.props.fetchLoadingSecrets()
+      }
 
-        if (Object.keys(this.props.baseInfo.appNavConfigMap).length === 0) {
-            this.props.fetchLoadingAppNavConfigMaps();
-        }
+      if (Object.keys(this.props.baseInfo.appNavConfigMap).length === 0) {
+        this.props.fetchLoadingAppNavConfigMaps()
+      }
     }
 
     render() {
-        if (Object.keys(this.props.baseInfo.appNavConfigMap).length === 0){
-            return (<div></div>)
-        }
-        else{
+      if (Object.keys(this.props.baseInfo.appNavConfigMap).length === 0){
+        return (<div></div>)
+      }
+      else{
         return (
-            <div >
-                <main >
-                    <Router>
-                        <Switch >
-                            <Route exact path="/kappnav-ui/" component={AppView} />
+          <div >
+            <main >
+              <Router>
+                <Switch >
+                  <Route exact path="/kappnav-ui/" component={AppView} />
 
-                            <Route exact path="/kappnav-ui/applications" component={AppView} />
+                  <Route exact path="/kappnav-ui/applications" component={AppView} />
 
-                            <Route exact path="/kappnav-ui/jobs" component={JobView} />
+                  <Route exact path="/kappnav-ui/jobs" component={JobView} />
 
-                            <Route exact path="/kappnav-ui/applications/:applicationName" component={ComponentView} />
+                  <Route exact path="/kappnav-ui/applications/:applicationName" component={ComponentView} />
 
-                            <Route exact path="/kappnav-ui/was-nd-cells/:cellName/was-traditional-app/:applicationName" component={DetailView} />
-                        </Switch>
-                    </Router>
-                </main>
-            </div>
-        );
-        }
+                  <Route exact path="/kappnav-ui/was-nd-cells/:cellName/was-traditional-app/:applicationName" component={DetailView} />
+                </Switch>
+              </Router>
+            </main>
+          </div>
+        )
+      }
     }
 }
 
+ViewContainer.propTypes = {
+  baseInfo: PropTypes.object,
+  fetchLoadingAppNavConfigMaps: PropTypes.func,
+  fetchLoadingNamespaces: PropTypes.func,
+  fetchLoadingSecrets: PropTypes.func
+}
+
 export default connect(
-    (state) => ({
-        baseInfo: state.baseInfo,
-    }),
-    {
-        fetchLoadingNamespaces,
-        fetchLoadingSecrets,
-        fetchLoadingAppNavConfigMaps
-    }
-)(ViewContainer);
+  (state) => ({
+    baseInfo: state.baseInfo,
+  }),
+  {
+    fetchLoadingNamespaces,
+    fetchLoadingSecrets,
+    fetchLoadingAppNavConfigMaps
+  }
+)(ViewContainer)

--- a/src-web/components/kappnav/AppView.jsx
+++ b/src-web/components/kappnav/AppView.jsx
@@ -17,20 +17,23 @@
  *****************************************************************/
 
 import 'carbon-components/scss/globals/scss/styles.scss'
-import React, {Component} from 'react'
+import React, {Component} from 'react';
+import { connect } from 'react-redux'
 import {Loading, DataTable} from 'carbon-components-react'
 import ReactDOM from 'react-dom'
 import {CONTEXT_PATH, PAGE_SIZES, SORT_DIRECTION_ASCENDING, SORT_DIRECTION_DESCENDING, RESOURCE_TYPES} from '../../actions/constants'
 import {getRowSlice, sort, sortColumn, getOverflowMenu, getStatus, buildStatusHtml, getToken} from '../../actions/common'
 import msgs from '../../../nls/kappnav.properties'
 import ResourceTable from './common/ResourceTable.js'
+import SecondaryHeader from './common/SecondaryHeader.jsx'
 import getResourceData from '../../definitions/index'
 import ApplicationModal from './modals/ApplicationModal.js'
+import NamespaceDropdown from './common/NamespaceDropdown'
 
 
 const applicationResourceData = getResourceData(RESOURCE_TYPES.APPLICATION)
 
-class AppView extends React.Component {
+class AppView extends Component {
 
   constructor(props) {
     super(props);
@@ -57,10 +60,18 @@ class AppView extends React.Component {
     this.fetchData = this.fetchData.bind(this);
   }
   render() {
+    let viewTitle = msgs.get('page.applicationView.title');
+    
     if (this.state.loading)
       return <Loading withOverlay={false} className='content-spinner'/>
     else
       return (
+        <div>
+          <SecondaryHeader title={viewTitle} location={location}/>
+          <div className="page-content-container" role="main">
+
+          
+          <NamespaceDropdown />
         <ResourceTable
           rows={this.state.rows}
           headers={this.state.headers} title={''}
@@ -82,8 +93,8 @@ class AppView extends React.Component {
             this.handleSort(e)
           }}
           pageNumber={this.state.pageNumber}
-          namespace={this.props.namespace}
-          namespaces={this.props.namespaces}
+          namespace={this.props.baseInfo.selectedNamespace}
+          namespaces={this.props.baseInfo.namespaces}
           resourceType={applicationResourceData.resourceType}
           createNewModal={(namespace, namespaces, existingSecrets) => {
             return (
@@ -100,30 +111,34 @@ class AppView extends React.Component {
             )
           }}
         />
+        </div>
+        </div>
       );
     }
 
   componentDidMount() {
-    this.fetchData(this.props.namespace, this.state.search, this.props.appNavConfigData)
+    this.fetchData(this.props.baseInfo.selectedNamespace, this.state.search, this.props.baseInfo.appNavConfigMap)
 
-    if (!window.secondaryHeader.refreshCallback) {
-      window.secondaryHeader.refreshCallback = function(result) {
-        //Update Table
-        this.fetchData(this.props.namespace, undefined, this.props.appNavConfigData)
-      }.bind(this);
+    if(window.secondaryHeader !== undefined){
+      if (!window.secondaryHeader.refreshCallback) {
+        window.secondaryHeader.refreshCallback = function(result) {
+          //Update Table
+          this.fetchData(this.props.baseInfo.selectedNamespace, undefined, this.props.baseInfo.appNavConfigMap)
+        }.bind(this);
+      }
     }
 
     var self = this;
     window.setInterval(function(){
-      self.refreshData(self.props.namespace, self.state.search, self.props.appNavConfigData)
+      self.refreshData(self.props.baseInfo.selectedNamespace, self.state.search, self.props.baseInfo.appNavConfigMap)
     }, 10000);
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    if (this.props.namespace == nextProps.namespace) {
+    if (this.props.baseInfo.selectedNamespace == nextProps.baseInfo.selectedNamespace) {
       return true;
     } else {
-      this.fetchData(nextProps.namespace, undefined, this.props.appNavConfigData)
+      this.fetchData(nextProps.baseInfo.selectedNamespace, undefined, this.props.baseInfo.appNavConfigMap)
     }
     return false;
   }
@@ -191,14 +206,14 @@ class AppView extends React.Component {
   }
 
   displayComponents(name) {
-    let url = location.protocol + '//' + location.host + CONTEXT_PATH + '/applications/' + encodeURIComponent(name) + "?namespace=" + encodeURIComponent(props.namespace)
+    let url = location.protocol + '//' + location.host + CONTEXT_PATH + '/applications/' + encodeURIComponent(name) + "?namespace=" + encodeURIComponent(props.baseInfo.selectedNamespace)
     window.location.href = url
   }
 
   createApplication(data, errorCallback) {
     var refreshViewCallback = function(response) {
       if (response.status === 200) {
-        this.fetchData(this.props.namespace, undefined, this.props.appNavConfigData)
+        this.fetchData(this.props.baseInfo.selectedNamespace, undefined, this.props.baseInfo.appNavConfigMap)
 
       } else if(response.status && response.message) {
         //kube api exception
@@ -249,10 +264,15 @@ class AppView extends React.Component {
         itemObj.menuAction = getOverflowMenu(item, application["action-map"], applicationResourceData, undefined, undefined)
         rowArray.push(itemObj)
       });
-
       this.filterTable(search, this.state.pageNumber, this.state.pageSize, rowArray)
     });
   }
 } // end of AppView component
 
-export default AppView;
+export default connect(
+  (state) => ({
+      baseInfo: state.baseInfo,
+  }),
+  {
+  }
+)(AppView);

--- a/src-web/components/kappnav/AppView.jsx
+++ b/src-web/components/kappnav/AppView.jsx
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,33 +17,33 @@
  *****************************************************************/
 
 import 'carbon-components/scss/globals/scss/styles.scss'
-import React, {Component} from 'react';
+import React, {Component} from 'react'
 import { connect } from 'react-redux'
 import {Loading, DataTable} from 'carbon-components-react'
-import ReactDOM from 'react-dom'
-import {CONTEXT_PATH, PAGE_SIZES, SORT_DIRECTION_ASCENDING, SORT_DIRECTION_DESCENDING, RESOURCE_TYPES} from '../../actions/constants'
+import {CONTEXT_PATH, PAGE_SIZES, SORT_DIRECTION_ASCENDING, RESOURCE_TYPES} from '../../actions/constants'
 import {getRowSlice, sort, sortColumn, getOverflowMenu, getStatus, buildStatusHtml, getToken} from '../../actions/common'
 import msgs from '../../../nls/kappnav.properties'
 import ResourceTable from './common/ResourceTable.js'
 import SecondaryHeader from './common/SecondaryHeader.jsx'
+// eslint-disable-next-line import/no-named-as-default
 import getResourceData from '../../definitions/index'
 import ApplicationModal from './modals/ApplicationModal.js'
 import NamespaceDropdown from './common/NamespaceDropdown'
-
+import PropTypes from 'prop-types'
 
 const applicationResourceData = getResourceData(RESOURCE_TYPES.APPLICATION)
 
 class AppView extends Component {
 
   constructor(props) {
-    super(props);
+    super(props)
 
     this.state = {
       loading: true,
       totalRows: [],
       filteredRows: [],
       rows: [],
-      sortColumn: "status",
+      sortColumn: 'status',
       sortDirection: SORT_DIRECTION_ASCENDING,
       pageSize: PAGE_SIZES.DEFAULT,
       pageNumber: 1,
@@ -54,93 +54,92 @@ class AppView extends Component {
         {key: 'namespace', header: msgs.get('table.header.namespace')},
         {key: 'menuAction', header: msgs.get('table.header.action')}
       ]
-    };
+    }
 
     // make 'this' visible to class methods
-    this.fetchData = this.fetchData.bind(this);
+    this.fetchData = this.fetchData.bind(this)
   }
   render() {
-    let viewTitle = msgs.get('page.applicationView.title');
-    
+    const viewTitle = msgs.get('page.applicationView.title')
+
     if (this.state.loading)
-      return <Loading withOverlay={false} className='content-spinner'/>
+      return <Loading withOverlay={false} className='content-spinner' />
     else
       return (
         <div>
-          <SecondaryHeader title={viewTitle} location={location}/>
+          <SecondaryHeader title={viewTitle} location={location} />
           <div className="page-content-container" role="main">
 
-          
-          <NamespaceDropdown />
-        <ResourceTable
-          rows={this.state.rows}
-          headers={this.state.headers} title={''}
-          onInputChange={(e) => {
-            this.searchInputChange(e)
-          }}
-          totalNumberOfRows={this.state.filteredRows.length}
-          changeTablePage={(e) => {
-            this.handlePaginationClick(e)
-          }}
-          sortColumn={this.state.sortColumn}
-          sortDirection={this.state.sortDirection}
-        //filterItems={{
-        //                itemArray: [ { text:'Application', value:'application' }, { text:'Assembly', value:'assembly' } ],
-        //                filterLabel: "Type",
-        //                filterAction: (args) => {debugger;}
-        //              }}
-          handleSort={(e) => {
-            this.handleSort(e)
-          }}
-          pageNumber={this.state.pageNumber}
-          namespace={this.props.baseInfo.selectedNamespace}
-          namespaces={this.props.baseInfo.namespaces}
-          resourceType={applicationResourceData.resourceType}
-          createNewModal={(namespace, namespaces, existingSecrets) => {
-            return (
-              <DataTable.TableToolbarContent>
-                <ApplicationModal 
-                  createAction={(data, errorCallback) => {
-                    this.createApplication(data, errorCallback)
-                  }}
-                  namespace={namespace} 
-                  namespaces={namespaces} 
-                >
-                </ApplicationModal>
-              </DataTable.TableToolbarContent>
-            )
-          }}
-        />
+            <NamespaceDropdown />
+            <ResourceTable
+              rows={this.state.rows}
+              headers={this.state.headers} title={''}
+              onInputChange={(e) => {
+                this.searchInputChange(e)
+              }}
+              totalNumberOfRows={this.state.filteredRows.length}
+              changeTablePage={(e) => {
+                this.handlePaginationClick(e)
+              }}
+              sortColumn={this.state.sortColumn}
+              sortDirection={this.state.sortDirection}
+              //filterItems={{
+              //                itemArray: [ { text:'Application', value:'application' }, { text:'Assembly', value:'assembly' } ],
+              //                filterLabel: "Type",
+              //                filterAction: (args) => {debugger;}
+              //              }}
+              handleSort={(e) => {
+                this.handleSort(e)
+              }}
+              pageNumber={this.state.pageNumber}
+              namespace={this.props.baseInfo.selectedNamespace}
+              namespaces={this.props.baseInfo.namespaces}
+              resourceType={applicationResourceData.resourceType}
+              createNewModal={(namespace, namespaces) => {
+                return (
+                  <DataTable.TableToolbarContent>
+                    <ApplicationModal
+                      createAction={(data, errorCallback) => {
+                        this.createApplication(data, errorCallback)
+                      }}
+                      namespace={namespace}
+                      namespaces={namespaces}
+                    >
+                    </ApplicationModal>
+                  </DataTable.TableToolbarContent>
+                )
+              }}
+            />
+          </div>
         </div>
-        </div>
-      );
-    }
+      )
+  }
 
   componentDidMount() {
     this.fetchData(this.props.baseInfo.selectedNamespace, this.state.search, this.props.baseInfo.appNavConfigMap)
 
     if(window.secondaryHeader !== undefined){
       if (!window.secondaryHeader.refreshCallback) {
-        window.secondaryHeader.refreshCallback = function(result) {
+        window.secondaryHeader.refreshCallback = function() {
           //Update Table
           this.fetchData(this.props.baseInfo.selectedNamespace, undefined, this.props.baseInfo.appNavConfigMap)
-        }.bind(this);
+        }.bind(this)
       }
     }
 
-    var self = this;
-    window.setInterval(function(){
+    var self = this
+    window.setInterval(() => {
       self.refreshData(self.props.baseInfo.selectedNamespace, self.state.search, self.props.baseInfo.appNavConfigMap)
-    }, 10000);
+    }, 10000)
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate(nextProps) {
     if (this.props.baseInfo.selectedNamespace == nextProps.baseInfo.selectedNamespace) {
-      return true;
+      return true
     } else {
       this.fetchData(nextProps.baseInfo.selectedNamespace, undefined, this.props.baseInfo.appNavConfigMap)
     }
-    return false;
+    return false
   }
 
   handlePaginationClick(e) {
@@ -161,25 +160,25 @@ class AppView extends Component {
             filteredRows.push(row)
             return
           }
-        } else if (('' + appName.appName).toLowerCase().includes(searchValue.toLowerCase())) {
+        } else if (('' + row.appName.appName).toLowerCase().includes(searchValue.toLowerCase())) {
           filteredRows.push(row)
           return
         }
 
         // There has to be a better way of getting the searchable text for status
-        let rowStatus = row.status.props.children[1].props.children
+        const rowStatus = row.status.props.children[1].props.children
 
         if (('' + rowStatus).toLowerCase().includes(searchValue.toLowerCase())) {
           filteredRows.push(row)
         }
-      });
+      })
     } else {
       //needed in case we are not searching
       filteredRows = totalRows
     }
 
     //sort the newList
-    let sortedList = sort(filteredRows, this.state.sortDirection, this.state.sortColumn)
+    const sortedList = sort(filteredRows, this.state.sortDirection, this.state.sortColumn)
 
     this.setState({
       loading: false,
@@ -189,24 +188,26 @@ class AppView extends Component {
       pageSize: pageSize,
       filteredRows: filteredRows,
       search: searchValue
-    });
+    })
   }
 
   handleSort(e) {
     const target = e.currentTarget
     if (target) {
       const newSortColumn = target && target.getAttribute('data-key')
-      let result = sortColumn(this.state.filteredRows, this.state.sortColumn, this.state.sortDirection, newSortColumn)
+      // eslint-disable-next-line react/no-access-state-in-setstate
+      const result = sortColumn(this.state.filteredRows, this.state.sortColumn, this.state.sortDirection, newSortColumn)
       this.setState({
+        // eslint-disable-next-line react/no-access-state-in-setstate
         rows: getRowSlice(result.sortedList, this.state.pageNumber, this.state.pageSize),
         sortColumn: newSortColumn,
         sortDirection: result.direction
-      });
+      })
     }
   }
 
   displayComponents(name) {
-    let url = location.protocol + '//' + location.host + CONTEXT_PATH + '/applications/' + encodeURIComponent(name) + "?namespace=" + encodeURIComponent(props.baseInfo.selectedNamespace)
+    const url = location.protocol + '//' + location.host + CONTEXT_PATH + '/applications/' + encodeURIComponent(name) + '?namespace=' + encodeURIComponent(this.props.baseInfo.selectedNamespace)
     window.location.href = url
   }
 
@@ -222,14 +223,14 @@ class AppView extends Component {
         //catch all
         errorCallback(msgs.get('error.parse.description'))
       }
-    }.bind(this);
+    }.bind(this)
 
     fetch('/kappnav/application?namespace=' + encodeURIComponent(data.metadata.namespace), {
-      method: "POST",
-      cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
+      method: 'POST',
+      cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
       headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        "CSRF-Token": getToken()
+        'Content-Type': 'application/json; charset=utf-8',
+        'CSRF-Token': getToken()
       },
       body: JSON.stringify(data)
     }).then(response => {
@@ -241,38 +242,40 @@ class AppView extends Component {
         }
       }
     })
-    .then(response => refreshViewCallback(response))
+      .then(response => refreshViewCallback(response))
   }
 
   fetchData(namespace, search, appNavConfigData) {
-    this.setState({loading: true});
+    this.setState({loading: true})
     this.refreshData(namespace, search, appNavConfigData)
   }
 
   refreshData(namespace, search, appNavConfigData) {
     fetch('/kappnav/applications?namespace=' + encodeURIComponent(namespace)).then(result => result.json()).then(result => {
-      var rowArray = [];
+      var rowArray = []
       result.applications.forEach((application) => {
-        var item = application.application;
-        var annotations = item.metadata.annotations;
-
-        var itemObj = {};
-        itemObj.id = item.metadata.uid+"-application"
+        var item = application.application
+        var itemObj = {}
+        itemObj.id = item.metadata.uid+'-application'
         itemObj.status = buildStatusHtml(getStatus(item.metadata, appNavConfigData))
         itemObj.appName = <a href={location.protocol + '//' + location.host + CONTEXT_PATH + '/applications/' + encodeURIComponent(item.metadata.name) + '?namespace=' + item.metadata.namespace}>{item.metadata.name}</a>
         itemObj.namespace = item.metadata.namespace
-        itemObj.menuAction = getOverflowMenu(item, application["action-map"], applicationResourceData, undefined, undefined)
+        itemObj.menuAction = getOverflowMenu(item, application['action-map'], applicationResourceData, undefined, undefined)
         rowArray.push(itemObj)
-      });
+      })
       this.filterTable(search, this.state.pageNumber, this.state.pageSize, rowArray)
-    });
+    })
   }
 } // end of AppView component
 
+AppView.propTypes = {
+  baseInfo: PropTypes.object
+}
+
 export default connect(
   (state) => ({
-      baseInfo: state.baseInfo,
+    baseInfo: state.baseInfo,
   }),
   {
   }
-)(AppView);
+)(AppView)

--- a/src-web/components/kappnav/ComponentView.jsx
+++ b/src-web/components/kappnav/ComponentView.jsx
@@ -88,6 +88,7 @@ class ComponentView extends Component {
     }
 
     const moduleTitle = msgs.get(resourceData.moduleKeys.title)
+    // eslint-disable-next-line no-unused-vars
     const moduleHeader =
     {/* esl failures for line between disable and enable: jsx-a11y/click-events-have-key-events and jsx-a11y/no-static-element-interactions */}
     {/* eslint-disable */}

--- a/src-web/components/kappnav/ComponentView.jsx
+++ b/src-web/components/kappnav/ComponentView.jsx
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +16,9 @@
  *
  *****************************************************************/
 
-import 'carbon-components/scss/globals/scss/styles.scss';
-import React, {Component} from 'react';
-import { connect } from 'react-redux';
+import 'carbon-components/scss/globals/scss/styles.scss'
+import React, {Component} from 'react'
+import { connect } from 'react-redux'
 import lodash from 'lodash'
 import { Module, ModuleBody } from 'carbon-addons-cloud-react'
 import { Loading } from 'carbon-components-react'
@@ -27,46 +27,46 @@ import StructuredListModule from './common/StructuredListModule'
 import { CONTEXT_PATH, PAGE_SIZES, SORT_DIRECTION_ASCENDING, RESOURCE_TYPES } from '../../actions/constants'
 import { getRowSlice, sort, sortColumn } from '../../actions/common'
 import SecondaryHeader from './common/SecondaryHeader.jsx'
+// eslint-disable-next-line import/no-named-as-default
 import getResourceData, { refreshResource, refreshResourceComponent } from '../../definitions/index'
 import msgs from '../../../nls/kappnav.properties'
+import PropTypes from 'prop-types'
 
 class ComponentView extends Component {
   constructor (props){
-    super(props);
+    super(props)
 
     this.state = {
       expanded: true,
       loading: true,
       loadingComponents: true,
-      actions: [],
       totalRows: [],
       filteredRows: [],
       rows: [],
-      sortColumn: "status",
+      sortColumn: 'status',
       sortDirection: SORT_DIRECTION_ASCENDING,
       pageSize: PAGE_SIZES.DEFAULT,
       pageNumber: 1,
-      search: undefined,
       resourceType : RESOURCE_TYPES.APPLICATION,
-      name : decodeURIComponent(location.pathname.split('/').filter(function (e) { return e })[2])
-    };
+      name : decodeURIComponent(location.pathname.split('/').filter((e) => { return e })[2])
+    }
 
-    this.fetchData = this.fetchData.bind(this);
+    this.fetchData = this.fetchData.bind(this)
     this.toggleExpandCollapse = this.toggleExpandCollapse.bind(this)
   }
 
   render() {
     const resourceType = this.state.resourceType
     const resourceData = getResourceData(resourceType)
-    let title = msgs.get('page.applicationView.title') // default = application
-    let titleUrl = CONTEXT_PATH + '/applications' // default = application
-    let resourceName = this.state.name
-    let breadcrumbItems = [
+    const title = msgs.get('page.applicationView.title') // default = application
+    const titleUrl = CONTEXT_PATH + '/applications' // default = application
+    const resourceName = this.state.name
+    const breadcrumbItems = [
       {label : title, url : titleUrl},
       {label : resourceName}
-      ]
+    ]
 
-    let basicDetailPane = <StructuredListModule
+    const basicDetailPane = <StructuredListModule
       title={resourceData.detailKeys.title}
       expanded={resourceData.detailKeys.expanded}
       headerRows={resourceData.detailKeys.headerRows}
@@ -74,7 +74,7 @@ class ComponentView extends Component {
       id={this.state.name+'-overview-module'}
       data={this.state.data} />
 
-    let additionalDetailPane;
+    let additionalDetailPane
     if(resourceData.additionalDetailKeys) {
       // Only create an additional details pane if the resource's
       // definition calls for it
@@ -87,23 +87,26 @@ class ComponentView extends Component {
         data={this.state.data} />
     }
 
-    let moduleTitle = msgs.get(resourceData.moduleKeys.title)
-    let moduleHeader = 
-      <div className='bx--module__header' style={{justifyContent: 'space-between'}} onClick={(e)=>{this.toggleExpandCollapse()}}>
-        <ul data-accordion className="bx--accordion">
-          <li data-accordion-item className="bx--accordion__item" className={this.state.expanded ? 'bx--accordion__item--active' : '' }>
-            <button className="bx--accordion__heading" aria-expanded={this.state.expanded} aria-controls={this.state.name+"modulePane"} title={this.state.expanded ? msgs.get('collapse') : msgs.get('expand') }>
-              <svg className="bx--accordion__arrow" width="7" height="12" viewBox="0 0 7 12">
-                <path fillRule="nonzero" d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z" />
-              </svg>
-              <div className="bx--accordion__title">{moduleTitle}</div>
-            </button>
-          </li>
-        </ul>
-      </div>
+    const moduleTitle = msgs.get(resourceData.moduleKeys.title)
+    const moduleHeader =
+    {/* esl failures for line between disable and enable: jsx-a11y/click-events-have-key-events and jsx-a11y/no-static-element-interactions */}
+    {/* eslint-disable */}
+    <div className='bx--module__header' style={{justifyContent: 'space-between'}} onClick={(e)=>{this.toggleExpandCollapse()}}>
+    {/* eslint-enable */}
+      <ul data-accordion className="bx--accordion">
+        <li data-accordion-item className={this.state.expanded ? 'bx--accordion__item--active' : '' }>
+          <button className="bx--accordion__heading" aria-expanded={this.state.expanded} aria-controls={this.state.name+'modulePane'} title={this.state.expanded ? msgs.get('collapse') : msgs.get('expand') }>
+            <svg className="bx--accordion__arrow" width="7" height="12" viewBox="0 0 7 12">
+              <path fillRule="nonzero" d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z" />
+            </svg>
+            <div className="bx--accordion__title">{moduleTitle}</div>
+          </button>
+        </li>
+      </ul>
+    </div>
 
-    let moduleBody = 
-      <ModuleBody id={this.state.name+"modulePane"} className={this.state.expanded ? '' : 'collapsed'}>
+    const moduleBody =
+      <ModuleBody id={this.state.name+'modulePane'} className={this.state.expanded ? '' : 'collapsed'}>
         {(() => {
           if(this.state.loadingComponents) {
             return <Loading withOverlay={false} className='module-spinner' />
@@ -128,33 +131,30 @@ class ComponentView extends Component {
         })()}
       </ModuleBody>
 
-console.log("viewTitle " + this.state.name + " breadcrumbItems " + breadcrumbItems  + "location " + location);
     return (
       <div>
-        <SecondaryHeader title={this.state.name} breadcrumbItems={breadcrumbItems} location={location}/>
-      
-      
-      <div className="page-content-container overview-content" role="main">
+        <SecondaryHeader title={this.state.name} breadcrumbItems={breadcrumbItems} location={location} />
+        <div className="page-content-container overview-content" role="main">
 
-        {(() => {
-          if (!this.state.loading) {
-            return (
-              <div className="stackedDetails">
-                { basicDetailPane }
-                { additionalDetailPane }
-              </div>
-            )
-          }
-        })()}
+          {(() => {
+            if (!this.state.loading) {
+              return (
+                <div className="stackedDetails">
+                  { basicDetailPane }
+                  { additionalDetailPane }
+                </div>
+              )
+            }
+          })()}
 
-        <Module className={this.state.expanded ? '' : 'collapsedModule' } id={this.state.name+'-component-module'}>
-          { moduleHeader }
-          { moduleBody }
-        </Module>
+          <Module className={this.state.expanded ? '' : 'collapsedModule' } id={this.state.name+'-component-module'}>
+            { this.moduleHeader }
+            { moduleBody }
+          </Module>
 
+        </div>
       </div>
-      </div>
-    );
+    )
   }
 
   getResourcePageUrl(resourceType) {
@@ -162,57 +162,58 @@ console.log("viewTitle " + this.state.name + " breadcrumbItems " + breadcrumbIte
   }
 
   componentDidMount(){
-    this.fetchData(this.state.name);
+    this.fetchData(this.state.name)
     if(window.secondaryHeader !== undefined){
-    if (!window.secondaryHeader.refreshCallback) {
-      console.log("I am here finally in componentDidMount")
-      window.secondaryHeader.refreshCallback = function(result) {
-        if(result && result.operation == "delete" && result.name == this.state.name) {
+      if (!window.secondaryHeader.refreshCallback) {
+        window.secondaryHeader.refreshCallback = function(result) {
+          if(result && result.operation == 'delete' && result.name == this.state.name) {
           //we just deleted the RESOURCE_TYPE that we are currently displaying. Go back to the RESOURCE_TYPE list.
-          let url= location.protocol+'//'+location.host + CONTEXT_PATH + '/' + this.getResourcePageUrl(this.state.resourceType);
-          window.location.href = url;
-        } else {
-          var skipComponentReload = true;
-          var originalResourceSpec = result && result.originalResource && result.originalResource.spec;
-          var newResourceSpec = result && result.newResource && result.newResource.spec;
-          if(originalResourceSpec && newResourceSpec &&
+            const url= location.protocol+'//'+location.host + CONTEXT_PATH + '/' + this.getResourcePageUrl(this.state.resourceType)
+            window.location.href = url
+          } else {
+            var skipComponentReload = true
+            var originalResourceSpec = result && result.originalResource && result.originalResource.spec
+            var newResourceSpec = result && result.newResource && result.newResource.spec
+            if(originalResourceSpec && newResourceSpec &&
             ( (originalResourceSpec.selector && newResourceSpec.selector && !lodash.isEqual(originalResourceSpec.selector.matchLabels, newResourceSpec.selector.matchLabels)) ||
               (originalResourceSpec.selector && newResourceSpec.selector && !lodash.isEqual(originalResourceSpec.selector.matchExpressions, newResourceSpec.selector.matchExpressions)) ||
               !lodash.isEqual(originalResourceSpec.componentKinds,newResourceSpec.componentKinds) )
-           ){
+            ){
             //Update Table only if the component list could be effected by the application edit
-            skipComponentReload = false;
+              skipComponentReload = false
+            }
+            this.fetchData(this.state.name, skipComponentReload)
           }
-          this.fetchData(this.state.name, skipComponentReload);
-        }
-      }.bind(this);
+        }.bind(this)
+      }
     }
-  }
 
-    var self = this;
-    window.setInterval(function(){
+    var self = this
+    window.setInterval(() => {
       refreshResource(self.state.name, self.props.baseInfo.selectedNamespace, self.state.resourceType, self.props.baseInfo.appNavConfigMap).then(result => {
-        self.setState({loading: false, data: result});
-      });
-    }, 10000);
+        self.setState({loading: false, data: result})
+      })
+    }, 10000)
 
     window.setInterval(function(){
       refreshResourceComponent(self.state.name, self.props.baseInfo.selectedNamespace, self.state.resourceType, self.props.baseInfo.appNavConfigMap).then(result => {
         if(result === null) {
-          this.setState({loadingComponents: false});
+          this.setState({loadingComponents: false})
         }
         self.filterTable(self.state.search, self.state.pageNumber, self.state.pageSize, result)
-      });
-    }, 30000);
+      })
+    }, 30000)
 
   }
 
   toggleExpandCollapse(){
-    this.setState({expanded: !this.state.expanded});
+    // eslint-disable-next-line react/no-access-state-in-setstate
+    this.setState({expanded: !this.state.expanded})
   }
 
   handlePaginationClick(e){
-	  this.setState({rows:getRowSlice(this.state.filteredRows, e.page, e.pageSize), pageNumber:e.page, pageSize:e.pageSize});
+    // eslint-disable-next-line react/no-access-state-in-setstate
+    this.setState({rows:getRowSlice(this.state.filteredRows, e.page, e.pageSize), pageNumber:e.page, pageSize:e.pageSize})
   }
 
   searchInputChange(e) {
@@ -220,41 +221,41 @@ console.log("viewTitle " + this.state.name + " breadcrumbItems " + breadcrumbIte
   }
 
   filterTable(searchValue, pageNumber, pageSize, totalRows){
-    let filteredRows = [];
+    let filteredRows = []
     //filter the rows
     if(searchValue) {
       totalRows.forEach((row) => {
         if(row.name.props) { //account for the possiblity of the name being a link
           if((''+row.name.props.children).toLowerCase().includes(searchValue.toLowerCase())){
-            filteredRows.push(row);
-            return;
+            filteredRows.push(row)
+            return
           }
         } else if((''+row.name).toLowerCase().includes(searchValue.toLowerCase())){
-          filteredRows.push(row);
-          return;
+          filteredRows.push(row)
+          return
         }
 
         // There has to be a better way of getting the searchable text for status
-        let rowStatus = row.status.props.children[1].props.children
+        const rowStatus = row.status.props.children[1].props.children
 
         if((''+row.compositeKind).toLowerCase().includes(searchValue.toLowerCase())){
-          filteredRows.push(row);
+          filteredRows.push(row)
         } else if((''+row.namespace).toLowerCase().includes(searchValue.toLowerCase())){
-          filteredRows.push(row);
+          filteredRows.push(row)
         } else if((''+row.platform).toLowerCase().includes(searchValue.toLowerCase())){
-          filteredRows.push(row);
+          filteredRows.push(row)
         } else if((''+rowStatus).toLowerCase().includes(searchValue.toLowerCase())){
-          filteredRows.push(row);
+          filteredRows.push(row)
         } else if((''+row.labels).toLowerCase().includes(searchValue.toLowerCase())){
-          filteredRows.push(row);
+          filteredRows.push(row)
         }
-      });
+      })
     } else {
-      filteredRows = totalRows;
+      filteredRows = totalRows
     }
 
     //sort the newList
-    var sortedList = sortedList = sort(filteredRows, this.state.sortDirection, this.state.sortColumn);
+    var sortedList = sortedList = sort(filteredRows, this.state.sortDirection, this.state.sortColumn)
 
     this.setState({
       loadingComponents: false,
@@ -263,41 +264,46 @@ console.log("viewTitle " + this.state.name + " breadcrumbItems " + breadcrumbIte
       pageNumber: pageNumber,
       pageSize: pageSize,
       filteredRows: filteredRows,
-      search: searchValue
-    });
+    })
   }
 
   handleSort(e) {
-   const target = e.currentTarget
-   if (target) {
-     const newSortColumn = target && target.getAttribute('data-key')
-     var result = sortColumn(this.state.filteredRows, this.state.sortColumn, this.state.sortDirection, newSortColumn);
-     this.setState({rows:getRowSlice(result.sortedList, this.state.pageNumber, this.state.pageSize), sortColumn:newSortColumn, sortDirection:result.direction});
-   }
- }
-
-fetchData(name, skipComponentReload) {
-  this.setState({loading: true, loadingComponents: !skipComponentReload});
-
-  refreshResource(name, this.props.baseInfo.selectedNamespace, this.state.resourceType, this.props.baseInfo.appNavConfigMap).then(result => {
-    this.setState({loading: false, data: result})
-  });
-
-  var self = this;
-  if(!skipComponentReload) {
-    refreshResourceComponent(name, this.props.baseInfo.selectedNamespace, this.state.resourceType, this.props.baseInfo.appNavConfigMap).then(result => {
-      self.setState({loadingComponents: false});
-      self.filterTable(self.state.search, this.state.pageNumber, this.state.pageSize, result)
-    });
+    const target = e.currentTarget
+    if (target) {
+      const newSortColumn = target && target.getAttribute('data-key')
+      // eslint-disable-next-line react/no-access-state-in-setstate
+      var result = sortColumn(this.state.filteredRows, this.state.sortColumn, this.state.sortDirection, newSortColumn)
+      // eslint-disable-next-line react/no-access-state-in-setstate
+      this.setState({rows:getRowSlice(result.sortedList, this.state.pageNumber, this.state.pageSize), sortColumn:newSortColumn, sortDirection:result.direction})
+    }
   }
-}
+
+  fetchData(name, skipComponentReload) {
+    this.setState({loading: true, loadingComponents: !skipComponentReload})
+
+    refreshResource(name, this.props.baseInfo.selectedNamespace, this.state.resourceType, this.props.baseInfo.appNavConfigMap).then(result => {
+      this.setState({loading: false, data: result})
+    })
+
+    var self = this
+    if(!skipComponentReload) {
+      refreshResourceComponent(name, this.props.baseInfo.selectedNamespace, this.state.resourceType, this.props.baseInfo.appNavConfigMap).then(result => {
+        self.setState({loadingComponents: false})
+        self.filterTable(self.state.search, this.state.pageNumber, this.state.pageSize, result)
+      })
+    }
+  }
 
 } // end of ComponentView component
 
+ComponentView.propTypes = {
+  baseInfo: PropTypes.object
+}
+
 export default connect(
   (state) => ({
-      baseInfo: state.baseInfo,
+    baseInfo: state.baseInfo,
   }),
   {
   }
-)(ComponentView);
+)(ComponentView)

--- a/src-web/components/kappnav/DetailView.jsx
+++ b/src-web/components/kappnav/DetailView.jsx
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +17,15 @@
  *****************************************************************/
 
 import 'carbon-components/scss/globals/scss/styles.scss'
-import React, {Component} from 'react';
-import { connect } from 'react-redux';
+import React, {Component} from 'react'
+import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { Loading } from 'carbon-components-react'
 import StructuredListModule from './common/StructuredListModule'
 import {updateSecondaryHeader, getOverflowMenu, getStatus} from '../../actions/common'
 import SecondaryHeader from './common/SecondaryHeader.jsx'
+import msgs from '../../../nls/kappnav.properties'
+import { CONTEXT_PATH } from '../../actions/constants'
 
 
 class DetailView extends Component {
@@ -33,7 +35,7 @@ class DetailView extends Component {
     this.state = {
       data: {},
       loading: true,
-      name : decodeURIComponent(location.pathname.split('/').filter(function (e) { return e })[4])
+      name : decodeURIComponent(location.pathname.split('/').filter((e) => { return e })[4])
     }
 
     this.fetchData = this.fetchData.bind(this)
@@ -41,54 +43,56 @@ class DetailView extends Component {
 
   render() {
     var paths = location.pathname.split('/')
-    paths = paths.filter(function (e) { return e })
-    let title = msgs.get('page.applicationView.title')
-    let name = decodeURIComponent(paths[2])
-    let parent_ns = decodeURIComponent(url.searchParams.get("parentnamespace"))
-    let itemName = decodeURIComponent(paths[4])
-    let ns = decodeURIComponent(url.searchParams.get("namespace"))
-    
-    let breadcrumbItems=[{label:title, url:CONTEXT_PATH+'/' + paths[1]},
-                          {label:name, url:CONTEXT_PATH+'/'+paths[1]+'/'+encodeURIComponent(name)+'?namespace='+encodeURIComponent(parent_ns)},
-                          {label:itemName, url:CONTEXT_PATH+'/'+paths[1]+'/'+encodeURIComponent(name)+'/'+resourceType+'/'+encodeURIComponent(itemName)+'?namespace='+encodeURIComponent(ns)+'&parentnamespace='+encodeURIComponent(parent_ns)} ]
+    paths = paths.filter((e) => { return e })
+    const title = msgs.get('page.applicationView.title')
+    const name = decodeURIComponent(paths[2])
+    // eslint-disable-next-line no-undef
+    const parent_ns = decodeURIComponent(url.searchParams.get('parentnamespace'))
+    const itemName = decodeURIComponent(paths[4])
+    // eslint-disable-next-line no-undef
+    const ns = decodeURIComponent(url.searchParams.get('namespace'))
+
+    const breadcrumbItems=[{label:title, url:CONTEXT_PATH+'/' + paths[1]},
+      {label:name, url:CONTEXT_PATH+'/'+paths[1]+'/'+encodeURIComponent(name)+'?namespace='+encodeURIComponent(parent_ns)},
+      // eslint-disable-next-line no-undef
+      {label:itemName, url:CONTEXT_PATH+'/'+paths[1]+'/'+encodeURIComponent(name)+'/'+resourceType+'/'+encodeURIComponent(itemName)+'?namespace='+encodeURIComponent(ns)+'&parentnamespace='+encodeURIComponent(parent_ns)} ]
 
     if (this.state.loading)
       return <Loading withOverlay={false} className='content-spinner' />
     else return (
       <div>
-        <SecondaryHeader title={this.state.name} breadcrumbItems={breadcrumbItems} location={location}/>
-      <div className="page-content-container" role="main">
-      
-      <StructuredListModule
-        title={this.props.staticResourceData.detailKeys.title}
-        headerRows={this.props.staticResourceData.detailKeys.headerRows}
-        rows={this.props.staticResourceData.detailKeys.rows}
-        id={this.state.name+'-overview-module'}
-        data={this.state.data} />
+        <SecondaryHeader title={this.state.name} breadcrumbItems={breadcrumbItems} location={location} />
+        <div className="page-content-container" role="main">
+          <StructuredListModule
+            title={this.props.staticResourceData.detailKeys.title}
+            headerRows={this.props.staticResourceData.detailKeys.headerRows}
+            rows={this.props.staticResourceData.detailKeys.rows}
+            id={this.state.name+'-overview-module'}
+            data={this.state.data} />
         </div>
-        </div>
+      </div>
     )
   }
 
   componentDidMount(){
     this.fetchData(this.state.name, this.props.baseInfo.selectedNamespace)
     if(window.secondaryHeader !== undefined){
-    if (!window.secondaryHeader.refreshCallback) {
-      window.secondaryHeader.refreshCallback = function(result) {
-        if(result && result.operation == 'delete' && result.name == this.state.name){
-          const breadcrumbs = window.secondaryHeader.props.breadcrumbItems
-          let url= '/'+this.props.staticResourceData.resourceType+'s'
-          if(breadcrumbs) {
-            url = breadcrumbs[breadcrumbs.length-2].url
-          }
-          window.location.href = location.protocol+'//'+location.host+url
-        } else {
+      if (!window.secondaryHeader.refreshCallback) {
+        window.secondaryHeader.refreshCallback = function(result) {
+          if(result && result.operation == 'delete' && result.name == this.state.name){
+            const breadcrumbs = window.secondaryHeader.props.breadcrumbItems
+            let url= '/'+this.props.staticResourceData.resourceType+'s'
+            if(breadcrumbs) {
+              url = breadcrumbs[breadcrumbs.length-2].url
+            }
+            window.location.href = location.protocol+'//'+location.host+url
+          } else {
           //Update Table
-          this.fetchData(this.state.name, this.props.baseInfo.selectedNamespace)
-        }
-      }.bind(this)
+            this.fetchData(this.state.name, this.props.baseInfo.selectedNamespace)
+          }
+        }.bind(this)
+      }
     }
-  }
 
     var self = this
     window.setInterval(() => {
@@ -126,7 +130,7 @@ class DetailView extends Component {
                 updateSecondaryHeader(getStatus(metadata, this.props.baseInfo.appNavConfigMap).statusColor, getStatus(metadata, this.props.baseInfo.appNavConfigMap).statusText, getOverflowMenu(result, undefined, this.props.staticResourceData, undefined, undefined))
                 return null
               } else {
-                return response.json();
+                return response.json()
               }
             }).then(actions => {
               if (actions) {
@@ -153,13 +157,14 @@ class DetailView extends Component {
 } // end of DetailView component
 
 DetailView.propTypes = {
+  baseInfo: PropTypes.object,
   staticResourceData: PropTypes.object.isRequired
 }
 
 export default connect(
   (state) => ({
-      baseInfo: state.baseInfo,
+    baseInfo: state.baseInfo,
   }),
   {
   }
-)(DetailView);
+)(DetailView)

--- a/src-web/components/kappnav/JobView.jsx
+++ b/src-web/components/kappnav/JobView.jsx
@@ -289,7 +289,7 @@ class JobView extends Component {
           // Not every K8 platform has a URL for displaying K8 Job kind details
           itemObj.actionName = jobName
         }
-        
+
         var applicationName = metadataLabel['kappnav-job-application-name']
         if (applicationName && applicationName === 'kappnav.not.assigned') {
           itemObj.appName = msgs.get('not.assigned')

--- a/src-web/components/kappnav/JobView.jsx
+++ b/src-web/components/kappnav/JobView.jsx
@@ -17,11 +17,13 @@
  *****************************************************************/
 
 import 'carbon-components/scss/globals/scss/styles.scss'
-import React from 'react'
+import React, {Component} from 'react';
+import { connect } from 'react-redux'
 import {Loading} from 'carbon-components-react'
 import {CONTEXT_PATH, PAGE_SIZES, SORT_DIRECTION_ASCENDING, RESOURCE_TYPES, STATUS_COLORS} from '../../actions/constants'
 import {getRowSlice, sort, sortColumn, getOverflowMenu, buildStatusHtml, getAge, getAgeDifference, getCreationTime, performUrlAction} from '../../actions/common'
 import msgs from '../../../nls/kappnav.properties'
+import SecondaryHeader from './common/SecondaryHeader.jsx'
 import ResourceTable from './common/ResourceTable.js'
 import getResourceData from '../../definitions/index'
 import PropTypes from 'prop-types'
@@ -30,7 +32,8 @@ import PropTypes from 'prop-types'
 const jobResourceData = getResourceData(RESOURCE_TYPES.JOB)
 
 // This is the view that shows a collection of Command Actions jobs
-class JobView extends React.Component {
+class JobView extends Component {
+  
 
   constructor(props) {
     super(props);
@@ -59,10 +62,16 @@ class JobView extends React.Component {
     this.fetchData = this.fetchData.bind(this);
   }
   render() {
+    let viewTitle = msgs.get('page.jobsView.title');
     if (this.state.loading)
       return <Loading withOverlay={false} className='content-spinner'/>
     else
       return (
+        <div>
+          <SecondaryHeader title={viewTitle} location={location}/>
+          <div className="page-content-container" role="main">
+
+        
         <ResourceTable
           rows={this.state.rows}
           headers={this.state.headers} title={''}
@@ -79,28 +88,30 @@ class JobView extends React.Component {
             this.handleSort(e)
           }}
           pageNumber={this.state.pageNumber}
-          namespace={this.props.namespace}
-          namespaces={this.props.namespaces}
+          namespace={this.props.baseInfo.selectedNamespace}
+          namespaces={this.props.baseInfo.namespaces}
         />
+        </div>
+        </div>
       )
   }
 
   componentDidMount() {
-    this.fetchData(this.props.namespace, this.state.search, this.props.appNavConfigData)
+    this.fetchData(this.props.baseInfo.selectedNamespace, this.state.search, this.props.baseInfo.appNavConfigMap)
 
     this.fetchJobUrlPattern()
 
     var self = this
     window.setInterval(() => {
-      self.refreshData(self.props.namespace, self.state.search, self.props.appNavConfigData)
+      self.refreshData(self.props.baseInfo.selectedNamespace, self.state.search, self.props.baseInfo.appNavConfigMap)
     }, 10000)
   }
 
   shouldComponentUpdate(nextProps) {
-    if (this.props.namespace == nextProps.namespace) {
+    if (this.props.baseInfo.selectedNamespace == nextProps.baseInfo.selectedNamespace) {
       return true
     } else {
-      this.fetchData(nextProps.namespace, undefined, this.props.appNavConfigData)
+      this.fetchData(nextProps.baseInfo.selectedNamespace, undefined, this.props.baseInfo.appNavConfigMap)
     }
     return false
   }
@@ -302,10 +313,10 @@ class JobView extends React.Component {
   }
 } // end of JobView component
 
-JobView.propTypes = {
-  appNavConfigData: PropTypes.object.isRequired,
-  namespace: PropTypes.string.isRequired,
-  namespaces: PropTypes.array.isRequired
-}
-
-export default JobView
+export default connect(
+  (state) => ({
+      baseInfo: state.baseInfo,
+  }),
+  {
+  }
+)(JobView);

--- a/src-web/components/kappnav/JobView.jsx
+++ b/src-web/components/kappnav/JobView.jsx
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@
  *****************************************************************/
 
 import 'carbon-components/scss/globals/scss/styles.scss'
-import React, {Component} from 'react';
+import React, {Component} from 'react'
 import { connect } from 'react-redux'
 import {Loading} from 'carbon-components-react'
 import {CONTEXT_PATH, PAGE_SIZES, SORT_DIRECTION_ASCENDING, RESOURCE_TYPES, STATUS_COLORS} from '../../actions/constants'
@@ -33,10 +33,9 @@ const jobResourceData = getResourceData(RESOURCE_TYPES.JOB)
 
 // This is the view that shows a collection of Command Actions jobs
 class JobView extends Component {
-  
 
   constructor(props) {
-    super(props);
+    super(props)
 
     this.state = {
       loading: true,
@@ -56,42 +55,41 @@ class JobView extends Component {
         {key: 'age', header: msgs.get('table.header.age')},
         {key: 'menuAction', header: msgs.get('table.header.action')}
       ]
-    };
+    }
 
     // make 'this' visible to class methods
-    this.fetchData = this.fetchData.bind(this);
+    this.fetchData = this.fetchData.bind(this)
   }
   render() {
-    let viewTitle = msgs.get('page.jobsView.title');
+    const viewTitle = msgs.get('page.jobsView.title')
     if (this.state.loading)
-      return <Loading withOverlay={false} className='content-spinner'/>
+      return <Loading withOverlay={false} className='content-spinner' />
     else
       return (
         <div>
-          <SecondaryHeader title={viewTitle} location={location}/>
+          <SecondaryHeader title={viewTitle} location={location} />
           <div className="page-content-container" role="main">
 
-        
-        <ResourceTable
-          rows={this.state.rows}
-          headers={this.state.headers} title={''}
-          onInputChange={(e) => {
-            this.searchInputChange(e)
-          }}
-          totalNumberOfRows={this.state.filteredRows.length}
-          changeTablePage={(e) => {
-            this.handlePaginationClick(e)
-          }}
-          sortColumn={this.state.sortColumn}
-          sortDirection={this.state.sortDirection}
-          handleSort={(e) => {
-            this.handleSort(e)
-          }}
-          pageNumber={this.state.pageNumber}
-          namespace={this.props.baseInfo.selectedNamespace}
-          namespaces={this.props.baseInfo.namespaces}
-        />
-        </div>
+            <ResourceTable
+              rows={this.state.rows}
+              headers={this.state.headers} title={''}
+              onInputChange={(e) => {
+                this.searchInputChange(e)
+              }}
+              totalNumberOfRows={this.state.filteredRows.length}
+              changeTablePage={(e) => {
+                this.handlePaginationClick(e)
+              }}
+              sortColumn={this.state.sortColumn}
+              sortDirection={this.state.sortDirection}
+              handleSort={(e) => {
+                this.handleSort(e)
+              }}
+              pageNumber={this.state.pageNumber}
+              namespace={this.props.baseInfo.selectedNamespace}
+              namespaces={this.props.baseInfo.namespaces}
+            />
+          </div>
         </div>
       )
   }
@@ -131,7 +129,7 @@ class JobView extends Component {
       .then(result => {
         var data = result.data
         let urlWithVariables = undefined
-        let urlActions = JSON.parse(data['url-actions'])
+        const urlActions = JSON.parse(data['url-actions'])
         if(urlActions.length === 0) {
           urlWithVariables = ''
         } else {
@@ -152,7 +150,7 @@ class JobView extends Component {
       totalRows.forEach((row) => {
         if (row.appName.props) {
           // Account for the possiblity of the name being a link
-          // When the application name is a link, the searchable application name text is 
+          // When the application name is a link, the searchable application name text is
           // under the "props" key
           if (('' + row.appName.props.children).toLowerCase().includes(searchValueLowerCase)) {
             filteredRows.push(row)
@@ -174,7 +172,7 @@ class JobView extends Component {
         })
 
         if(searchFields.some(field => field.includes(searchValueLowerCase))) {
-          // If one of the fields contains the search string, add the row 
+          // If one of the fields contains the search string, add the row
           // to what will be showed in filtered view
           filteredRows.push(row)
           return
@@ -301,7 +299,7 @@ class JobView extends Component {
           </a>
         }
 
-        const createdTime = getCreationTime(job);
+        const createdTime = getCreationTime(job)
         const howOldInMilliseconds = getAgeDifference(createdTime).diffDuration + ''
         itemObj.age = <div data-sorttitle={howOldInMilliseconds}>{getAge(job)}</div>
         itemObj.component = metadataLabel['kappnav-job-component-namespace'] + '/' + metadataLabel['kappnav-job-component-name']
@@ -313,10 +311,14 @@ class JobView extends Component {
   }
 } // end of JobView component
 
+JobView.propTypes = {
+  baseInfo: PropTypes.object
+}
+
 export default connect(
   (state) => ({
-      baseInfo: state.baseInfo,
+    baseInfo: state.baseInfo,
   }),
   {
   }
-)(JobView);
+)(JobView)

--- a/src-web/components/kappnav/common/FormField.js
+++ b/src-web/components/kappnav/common/FormField.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@
 import React from 'react'
 import { FormItem, FormLabel, Tooltip } from 'carbon-components-react'
 import msgs from '../../../../nls/kappnav.properties'
+import PropTypes from 'prop-types'
 
 require('../../../../scss/create-resource.scss')
 
@@ -41,5 +42,18 @@ const LabelTooltip = ({ labelText, content, required }) =>
     <p dangerouslySetInnerHTML={{ __html: content}} />
   </Tooltip>
 
+FieldWrapper.propTypes = {
+  children: PropTypes.object.isRequired,
+  className: PropTypes.string,
+  content: PropTypes.string,
+  labelText: PropTypes.string,
+  required: PropTypes.bool
+}
+
+LabelTooltip.propTypes = {
+  content: PropTypes.string,
+  labelText: PropTypes.string.isRequired,
+  required: PropTypes.bool
+}
 
 export { FieldWrapper, LabelTooltip }

--- a/src-web/components/kappnav/common/ModalFormItems.js
+++ b/src-web/components/kappnav/common/ModalFormItems.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ import msgs from '../../../../nls/kappnav.properties'
 import { TextInput, Icon, Select, SelectItem, NumberInput } from 'carbon-components-react'
 import withMultiple from './ModalListItem'
 import { FieldWrapper } from './FormField'
+import PropTypes from 'prop-types'
 
 const transform = (field, handleChange, event) => {
   handleChange(field, event.target.value)
@@ -45,7 +46,18 @@ const NumberField = ({ onChange, labelText, content, field, id, value, invalid, 
       onChange={handleNumberFieldChange.bind(this, field, onChange)} />
   </FieldWrapper>
 
-const General = ({ form, onChange, children, error, labelName, labelContent }, context) => {
+NumberField.propTypes = {
+  content: PropTypes.object,
+  field: PropTypes.string,
+  id: PropTypes.string,
+  invalid: PropTypes.bool,
+  labelText: PropTypes.string,
+  onChange: PropTypes.func,
+  required: PropTypes.bool,
+  value: PropTypes.number
+}
+
+const General = ({ form, onChange, children, error, labelName, labelContent }) => {
   const addOns = React.Children.map(children, child => {
     return React.cloneElement(child, { form, onChange, error })
   })
@@ -65,7 +77,16 @@ const General = ({ form, onChange, children, error, labelName, labelContent }, c
   </div>
 }
 
-const Label = ({ id, item, onModify, onRemove }, context) =>
+General.propTypes = {
+  children: PropTypes.object,
+  error: PropTypes.object,
+  form: PropTypes.object,
+  labelContent: PropTypes.string,
+  labelName: PropTypes.string,
+  onChange: PropTypes.func
+}
+
+const Label = ({ id, item, onModify, onRemove }) =>
   <div className='field-row'>
     <FieldWrapper labelText={msgs.get('formfield.label')} content={msgs.get('formtip.common.label.label')}>
       <TextInput
@@ -88,7 +109,14 @@ const Label = ({ id, item, onModify, onRemove }, context) =>
     <RemoveIcon id={`labels-remove-${id}`} onRemove={onRemove} />
   </div>
 
-const MatchLabel = ({ id, item, onModify, onRemove }, context) =>
+Label.propTypes = {
+  id: PropTypes.number,
+  item: PropTypes.object,
+  onModify: PropTypes.func,
+  onRemove: PropTypes.func
+}
+
+const MatchLabel = ({ id, item, onModify, onRemove }) =>
   <div className='field-row'>
     <FieldWrapper labelText={msgs.get('formfield.label')} content={msgs.get('formtip.common.matchLabel')}>
       <TextInput
@@ -111,7 +139,14 @@ const MatchLabel = ({ id, item, onModify, onRemove }, context) =>
     <RemoveIcon id={`labels-remove-${id}`} onRemove={onRemove} />
   </div>
 
-const RemoveIcon = ({ id, onRemove }, context) =>
+MatchLabel.propTypes = {
+  id: PropTypes.number,
+  item: PropTypes.object,
+  onModify: PropTypes.func,
+  onRemove: PropTypes.func
+}
+
+const RemoveIcon = ({ id, onRemove }) =>
   <Icon
     id={id}
     tabIndex='0'
@@ -122,18 +157,32 @@ const RemoveIcon = ({ id, onRemove }, context) =>
     style={{ 'margin': 'auto', 'minWidth': '4.25rem' }}
     fill='#8c9ba5' />
 
-const NamespaceSelect = ({ form, namespaces, onChange, labelName, labelContent }, context) =>
+RemoveIcon.propTypes = {
+  id: PropTypes.string,
+  onRemove: PropTypes.func
+}
+
+const NamespaceSelect = ({ form, namespaces, onChange, labelName, labelContent }) =>
   <FieldWrapper labelText={labelName || msgs.get('formfield.namespace')} content={labelContent || msgs.get('formtip.common.namespace')} required={true}>
     <Select
       id='namespace-select'
       value={form.namespace}
       hideLabel
       onChange={transform.bind(null, 'namespace', onChange)}>
+      {/* eslint-disable react/no-array-index-key */}
       {namespaces.map((namespace, index) => <SelectItem key={index} text={namespace.Name} value={namespace.Name} />)}
     </Select>
   </FieldWrapper>
 
-  const MatchExpression = ({ id, item, onModify, onRemove }, context) =>
+NamespaceSelect.propTypes = {
+  form: PropTypes.object,
+  labelContent: PropTypes.string,
+  labelName: PropTypes.string,
+  namespaces: PropTypes.array,
+  onChange: PropTypes.func
+}
+
+const MatchExpression = ({ id, item, onModify, onRemove }) =>
   <div className='field-row'>
     <FieldWrapper labelText={msgs.get('formfield.key')} content={msgs.get('formtip.selectors.matchExpression.key')}>
       <TextInput
@@ -165,28 +214,42 @@ const NamespaceSelect = ({ form, namespaces, onChange, labelName, labelContent }
     <RemoveIcon id={`match-expression-remove-${id}`} onRemove={onRemove} />
   </div>
 
-  const Kind = ({ id, item, onModify, onRemove }, context) =>
-    <div className='field-row'>
-      <FieldWrapper labelText={msgs.get('formfield.group')} content={msgs.get('formtip.common.group')}>
-        <TextInput
-          id={`labels-group-${id}`}
-          value={item.group}
-          hideLabel
-          className='bx--text-input-override'
-          labelText={msgs.get('formfield.group') + ' ' + msgs.get('formtip.common.group')}
-          onChange={onModify.bind(null, 'group')} />
-      </FieldWrapper>
-      <FieldWrapper labelText={msgs.get('formfield.kind')} content={msgs.get('formtip.common.kind')}>
-        <TextInput
-          id={`labels-kind-${id}`}
-          value={item.kind}
-          hideLabel
-          className='bx--text-input-override'
-          labelText={msgs.get('formfield.kind') + ' ' + msgs.get('formtip.common.kind')}
-          onChange={onModify.bind(null, 'kind')} />
-      </FieldWrapper>
-      <RemoveIcon id={`labels-remove-${id}`} onRemove={onRemove} />
-    </div>
+MatchExpression.propTypes = {
+  id: PropTypes.number,
+  item: PropTypes.object,
+  onModify: PropTypes.func,
+  onRemove: PropTypes.func
+}
+
+const Kind = ({ id, item, onModify, onRemove }) =>
+  <div className='field-row'>
+    <FieldWrapper labelText={msgs.get('formfield.group')} content={msgs.get('formtip.common.group')}>
+      <TextInput
+        id={`labels-group-${id}`}
+        value={item.group}
+        hideLabel
+        className='bx--text-input-override'
+        labelText={msgs.get('formfield.group')}
+        onChange={onModify.bind(null, 'group')} />
+    </FieldWrapper>
+    <FieldWrapper labelText={msgs.get('formfield.kind')} content={msgs.get('formtip.common.kind')}>
+      <TextInput
+        id={`labels-kind-${id}`}
+        value={item.kind}
+        hideLabel
+        className='bx--text-input-override'
+        labelText={msgs.get('formfield.kind')}
+        onChange={onModify.bind(null, 'kind')} />
+    </FieldWrapper>
+    <RemoveIcon id={`labels-remove-${id}`} onRemove={onRemove} />
+  </div>
+
+Kind.propTypes = {
+  id: PropTypes.number,
+  item: PropTypes.object,
+  onModify: PropTypes.func,
+  onRemove: PropTypes.func
+}
 
 const MatchExpressions = withMultiple(MatchExpression, { key: '', operator: '', values: ''})
 

--- a/src-web/components/kappnav/common/ModalListItem.js
+++ b/src-web/components/kappnav/common/ModalListItem.js
@@ -58,8 +58,7 @@ const withMultiple = (Component, newInstance) => {
       // eslint-disable-next-line react/prop-types
       return items.map((item, i) => {
         return <Component
-          // eslint-disable-next-line react/no-array-index-key
-          key={`${type}-${i}`}
+          key={`${type}-${item.id}`}
           item={item}
           id={i}
           error={error}
@@ -99,5 +98,7 @@ const withMultiple = (Component, newInstance) => {
     }
   }
 }
+
+
 
 export default withMultiple

--- a/src-web/components/kappnav/common/ModalListItem.js
+++ b/src-web/components/kappnav/common/ModalListItem.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  *****************************************************************/
- 
+
 'use strict'
 
 import React from 'react'
@@ -37,6 +37,7 @@ const withMultiple = (Component, newInstance) => {
     }
 
     render() {
+      // eslint-disable-next-line react/prop-types
       return (
         <div>
           {this.getItems()}
@@ -45,6 +46,7 @@ const withMultiple = (Component, newInstance) => {
             icon="add--glyph"
             iconDescription={msgs.get('svg.description.plus')}
             onClick={this.onAdd} >
+            {/* eslint-disable-next-line react/prop-types */}
             {this.props.addLabel}
           </Button>
         </div>
@@ -52,9 +54,12 @@ const withMultiple = (Component, newInstance) => {
     }
 
     getItems() {
+      // eslint-disable-next-line react/prop-types
       const { items, type, error } = this.props
+      // eslint-disable-next-line react/prop-types
       return items.map((item, i) => {
         return <Component
+          // eslint-disable-next-line react/no-array-index-key
           key={`${type}-${i}`}
           item={item}
           id={i}
@@ -65,24 +70,32 @@ const withMultiple = (Component, newInstance) => {
     }
 
     onAdd() {
+      // eslint-disable-next-line react/prop-types
       const { items, type } = this.props
       const newItem = newInstance ? Object.assign({}, newInstance) : ''
+      // eslint-disable-next-line react/prop-types
       const newItems = items.concat(newItem)
+      // eslint-disable-next-line react/prop-types
       this.props.onChange(type, newItems)
     }
 
     onModify(index, field, event) {
+      // eslint-disable-next-line react/prop-types
       const { items, type } = this.props
       let replacement = items[index]
       field ? lodash.set(replacement, field, event.target.value) : replacement = event.target.value
-      let newItems = [...items]
+      const newItems = [...items]
       newItems.splice(index, 1, replacement)
+      // eslint-disable-next-line react/prop-types
       this.props.onChange(type, newItems)
     }
 
     onRemove(index) {
+      // eslint-disable-next-line react/prop-types
       const { items, type } = this.props
+      // eslint-disable-next-line react/prop-types
       const newItems = items.filter((_, i) => i !== parseInt(index))
+      // eslint-disable-next-line react/prop-types
       this.props.onChange(type, newItems)
     }
   }

--- a/src-web/components/kappnav/common/ModalListItem.js
+++ b/src-web/components/kappnav/common/ModalListItem.js
@@ -37,7 +37,6 @@ const withMultiple = (Component, newInstance) => {
     }
 
     render() {
-      // eslint-disable-next-line react/prop-types
       return (
         <div>
           {this.getItems()}

--- a/src-web/components/kappnav/common/NamespaceDropdown.js
+++ b/src-web/components/kappnav/common/NamespaceDropdown.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,15 +15,16 @@
  * limitations under the License.
  *
  *****************************************************************/
- 
+
 'use strict'
 
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
 import lodash from 'lodash'
 import { DropdownV2 } from 'carbon-components-react'
-import msgs from '../../../../nls/kappnav.properties';
-import { fetchLoadingSelectedNamespace } from '../../../reducers/BaseServiceReducer';
+import msgs from '../../../../nls/kappnav.properties'
+import { fetchLoadingSelectedNamespace } from '../../../reducers/BaseServiceReducer'
+import PropTypes from 'prop-types'
 
 require('../../../../scss/namespace-dropdown.scss')
 
@@ -31,13 +32,8 @@ const translateWithId = (locale, id) => msgs.get(id)
 
 class NamespaceDropdown extends Component {
 
-  //state = {
-  //  isScrollingDownward: this.props.isScrollingDownward || false,
-  //  lastPosition: 0,
-  //}
-
   constructor(props) {
-    super(props);
+    super(props)
     this.state = {
       isScrollingDownward: false,
       lastPosition: 0
@@ -72,7 +68,7 @@ class NamespaceDropdown extends Component {
     window.addEventListener('scroll', this._debouncedScroll)
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.isScrollingDownward !== this.props.isScrollingDownward) {
       this.setState({ isScrollingDownward: nextProps.isScrollingDownward })
     }
@@ -84,17 +80,16 @@ class NamespaceDropdown extends Component {
 
   updateSelectedNamespace = (event) => {
     if(event.selectedItem.id == 'all'){
-        this.props.fetchLoadingSelectedNamespace('')
-      } else {
-        this.props.fetchLoadingSelectedNamespace(event.selectedItem.value)
-      }
+      this.props.fetchLoadingSelectedNamespace('')
+    } else {
+      this.props.fetchLoadingSelectedNamespace(event.selectedItem.value)
+    }
   }
 
   render() {
     //const { namespaces, selected_namespaces } = this.props
-    const namespaces = this.props.baseInfo.namespaces;
-    console.log("I m namespaces " + JSON.stringify(namespaces, null,4))
-    const selected_namespaces = this.props.baseInfo.selectedNamespace;
+    const namespaces = this.props.baseInfo.namespaces
+    const selected_namespaces = this.props.baseInfo.selectedNamespace
     const { isScrollingDownward } = this.state
     const hasMultipleNamespaces = namespaces && namespaces.length > 1
     let dropdownItems = Object.assign({}, namespaces)
@@ -107,7 +102,7 @@ class NamespaceDropdown extends Component {
     return <DropdownV2
       label={hasMultipleNamespaces ? msgs.get('namespaces.all', this.context.locale) : dropdownItems[0].label}
       ariaLabel={selected_namespaces.toString()}
-      className={`namespaces`}
+      className={`namespaces`} // eslint-disable-line quotes
       data-header-active={isScrollingDownward}
       //onChange={this.props.switchNamespace}
       onChange={(event) => this.updateSelectedNamespace(event)}
@@ -116,11 +111,18 @@ class NamespaceDropdown extends Component {
   }
 }
 
+NamespaceDropdown.propTypes = {
+  baseInfo: PropTypes.object,
+  fetchLoadingSelectedNamespace: PropTypes.func,
+  isScrollingDownward: PropTypes.bool,
+  namespaces: PropTypes.func
+}
+
 export default connect(
-    (state) => ({
-        baseInfo: state.baseInfo,
-    }),
-    {
-        fetchLoadingSelectedNamespace
-    }
-)(NamespaceDropdown);
+  (state) => ({
+    baseInfo: state.baseInfo,
+  }),
+  {
+    fetchLoadingSelectedNamespace
+  }
+)(NamespaceDropdown)

--- a/src-web/components/kappnav/common/NamespaceDropdown.js
+++ b/src-web/components/kappnav/common/NamespaceDropdown.js
@@ -18,17 +18,18 @@
  
 'use strict'
 
-import React from 'react'
-//import { connect } from 'react-redux'
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import lodash from 'lodash'
 import { DropdownV2 } from 'carbon-components-react'
-import msgs from '../../../../nls/kappnav.properties'
+import msgs from '../../../../nls/kappnav.properties';
+import { fetchLoadingSelectedNamespace } from '../../../reducers/BaseServiceReducer';
 
 require('../../../../scss/namespace-dropdown.scss')
 
 const translateWithId = (locale, id) => msgs.get(id)
 
-class NamespaceDropdown extends React.PureComponent {
+class NamespaceDropdown extends Component {
 
   //state = {
   //  isScrollingDownward: this.props.isScrollingDownward || false,
@@ -81,8 +82,19 @@ class NamespaceDropdown extends React.PureComponent {
     window.removeEventListener('scroll', this._debouncedScroll)
   }
 
+  updateSelectedNamespace = (event) => {
+    if(event.selectedItem.id == 'all'){
+        this.props.fetchLoadingSelectedNamespace('')
+      } else {
+        this.props.fetchLoadingSelectedNamespace(event.selectedItem.value)
+      }
+  }
+
   render() {
-    const { namespaces, selected_namespaces } = this.props
+    //const { namespaces, selected_namespaces } = this.props
+    const namespaces = this.props.baseInfo.namespaces;
+    console.log("I m namespaces " + JSON.stringify(namespaces, null,4))
+    const selected_namespaces = this.props.baseInfo.selectedNamespace;
     const { isScrollingDownward } = this.state
     const hasMultipleNamespaces = namespaces && namespaces.length > 1
     let dropdownItems = Object.assign({}, namespaces)
@@ -97,10 +109,18 @@ class NamespaceDropdown extends React.PureComponent {
       ariaLabel={selected_namespaces.toString()}
       className={`namespaces`}
       data-header-active={isScrollingDownward}
-      onChange={this.props.switchNamespace}
+      //onChange={this.props.switchNamespace}
+      onChange={(event) => this.updateSelectedNamespace(event)}
       translateWithId={translateWithId.bind(null, document.documentElement.lang)}
       items={dropdownItems} />
   }
 }
 
-export default NamespaceDropdown
+export default connect(
+    (state) => ({
+        baseInfo: state.baseInfo,
+    }),
+    {
+        fetchLoadingSelectedNamespace
+    }
+)(NamespaceDropdown);

--- a/src-web/components/kappnav/common/ResourceTable.js
+++ b/src-web/components/kappnav/common/ResourceTable.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,11 +16,12 @@
  *
  *****************************************************************/
 
-import 'carbon-components/scss/globals/scss/styles.scss';
-import React from 'react';
-import { PaginationV2, DataTable, Icon, MultiSelect } from 'carbon-components-react';
-import { PAGE_SIZES } from '../../../actions/constants';
-import msgs from '../../../../nls/kappnav.properties';
+import 'carbon-components/scss/globals/scss/styles.scss'
+import React from 'react'
+import { PaginationV2, DataTable, Icon, MultiSelect } from 'carbon-components-react'
+import { PAGE_SIZES } from '../../../actions/constants'
+import msgs from '../../../../nls/kappnav.properties'
+import PropTypes from 'prop-types'
 
 require('../../../../scss/table.scss')
 
@@ -28,123 +29,140 @@ const translateWithId = (locale, id) => msgs.get(id)
 
 class ResourceTable extends React.Component {
 
-	render() {
-		const {
-			title,
-			headers,
-			rows,
-			sortColumn,
-			sortDirection,
-			totalNumberOfRows,
-			changeTablePage,
-			onInputChange,
-			handleSort,
-			pageSize,
-			pageNumber,
-			filterItems,
-			namespace,
-			namespaces, //this is a list of namespaces that we use to populate the create new modals
-			existingSecrets,
-			createNewModal
-		} = this.props
+  render() {
+    const {
+      title,
+      headers,
+      rows,
+      sortColumn,
+      sortDirection,
+      totalNumberOfRows,
+      changeTablePage,
+      onInputChange,
+      handleSort,
+      pageSize,
+      pageNumber,
+      filterItems,
+      namespace,
+      namespaces, //this is a list of namespaces that we use to populate the create new modals
+      existingSecrets,
+      createNewModal
+    } = this.props
 
     return (
-			<div>
-				<DataTable
-				  rows={rows}
-				  headers={headers}
-				  translateWithId={translateWithId.bind(null, document.documentElement.lang)}
-				  render={({ rows, headers, getHeaderProps }) => (
-						<div>
-					<DataTable.TableContainer title={title}>
-					  <DataTable.TableToolbar>
-						  <DataTable.TableToolbarSearch onChange={onInputChange} closeButtonLabelText={msgs.get('modal.button.close')} translateWithId={translateWithId.bind(null, document.documentElement.lang)}/>
-							{(() => {
-			          if(filterItems !== undefined) {
-			            return (
-										<MultiSelect
-											label={filterItems.filterLabel}
-											items={filterItems.itemArray}
-											itemToString={item=>(item ? item.text : '')}
-											onChange={filterItems.filter}
-										/>
-									)
-								}
- 		          })()}
-						  {(() => {
-			          if(createNewModal !== undefined) {
-						return (createNewModal(namespace==''?'default':namespace, namespaces, existingSecrets))
-			          }
-		          })()}
-					  </DataTable.TableToolbar>
+      <div>
+        <DataTable
+          rows={rows}
+          headers={headers}
+          translateWithId={translateWithId.bind(null, document.documentElement.lang)}
+          render={({ rows, headers}) => (
+            <div>
+              <DataTable.TableContainer title={title}>
+                <DataTable.TableToolbar>
+                  <DataTable.TableToolbarSearch onChange={onInputChange} closeButtonLabelText={msgs.get('modal.button.close')} translateWithId={translateWithId.bind(null, document.documentElement.lang)} />
+                  {(() => {
+                    if(filterItems !== undefined) {
+                      return (
+                        <MultiSelect
+                          label={filterItems.filterLabel}
+                          items={filterItems.itemArray}
+                          itemToString={item=>(item ? item.text : '')}
+                          onChange={filterItems.filter}
+                        />
+                      )
+                    }
+                  })()}
+                  {(() => {
+                    if(createNewModal !== undefined) {
+                      return (createNewModal(namespace==''?'default':namespace, namespaces, existingSecrets))
+                    }
+                  })()}
+                </DataTable.TableToolbar>
 
-					  <DataTable.Table>
-						<DataTable.TableHead>
-						  <DataTable.TableRow>
-						    {(() => {
-							  return headers.map(header => {
-									if(header.key === 'menuAction') {
-									  return (
-									    <DataTable.TableHeader key={header.key}>
-										    <span className='bx--table-header-label'>{header.header}</span>
-									  	</DataTable.TableHeader>
-									  )
-									} else {
-								      return (
-	                        <th scope={'col'} key={header.key}>
-	                          <button
-															title={msgs.get(`svg.description.${!sortColumn || sortDirection === 'desc' ? 'asc' : 'desc'}`)}
-	                            onClick={handleSort}
-	                            className={`bx--table-sort-v2${sortDirection === 'asc' ? ' bx--table-sort-v2--ascending' : ''}${sortColumn === header.key ? ' bx--table-sort-v2--active' : ''}`}
-	                            data-key={header.key}
-	                          >
-	                            <span className='bx--table-header-label'>{header.header}</span>
-	                            <Icon
-	                              className='bx--table-sort-v2__icon'
-	                              name='caret--down'
-	                              description={msgs.get(`svg.description.${!sortColumn || sortDirection === 'desc' ? 'asc' : 'desc'}`)} />
-	                          </button>
-	                        </th>
-	                      )
-									}
-							  })
-							})()}
-						  </DataTable.TableRow>
-						</DataTable.TableHead>
-						<DataTable.TableBody>
-						  {rows.map(row => (
-							<DataTable.TableRow key={row.id}>
-							   {(() => {
-							     return row.cells.map(cell => (
-										<DataTable.TableCell key={cell.id}>{cell.value}</DataTable.TableCell>
-								 ))
-							   })()}
-							</DataTable.TableRow>
-						  ))}
-						</DataTable.TableBody>
-					  </DataTable.Table>
-					</DataTable.TableContainer>
-					<PaginationV2
-						key='pagination'
-						id='resource-table-pagination'
-						onChange={changeTablePage}
-						pageSize={pageSize || PAGE_SIZES.DEFAULT}
-						page={pageNumber}
-						pageSizes={PAGE_SIZES.VALUES}
-						totalItems={totalNumberOfRows}
-						isLastPage={false}
-						itemsPerPageText={msgs.get('pagination.itemsPerPage')}
-						pageRangeText={(current, total) => msgs.get('pagination.pageRange', [current, total])}
-						itemRangeText={(min, max, total) => `${msgs.get('pagination.itemRange', [min, max])} ${msgs.get('pagination.itemRangeDescription', [total])}`}
-					/>
-			</div>
-				  )}
-				/>
-			</div>
-    );
+                <DataTable.Table>
+                  <DataTable.TableHead>
+                    <DataTable.TableRow>
+                      {(() => {
+                        return headers.map(header => {
+                          if(header.key === 'menuAction') {
+                            return (
+                              <DataTable.TableHeader key={header.key}>
+                                <span className='bx--table-header-label'>{header.header}</span>
+                              </DataTable.TableHeader>
+                            )
+                          } else {
+                            return (
+                              <th scope={'col'} key={header.key}>
+                                <button
+                                  title={msgs.get(`svg.description.${!sortColumn || sortDirection === 'desc' ? 'asc' : 'desc'}`)}
+                                  onClick={handleSort}
+                                  className={`bx--table-sort-v2${sortDirection === 'asc' ? ' bx--table-sort-v2--ascending' : ''}${sortColumn === header.key ? ' bx--table-sort-v2--active' : ''}`}
+                                  data-key={header.key}
+                                >
+                                  <span className='bx--table-header-label'>{header.header}</span>
+                                  <Icon
+                                    className='bx--table-sort-v2__icon'
+                                    name='caret--down'
+                                    description={msgs.get(`svg.description.${!sortColumn || sortDirection === 'desc' ? 'asc' : 'desc'}`)} />
+                                </button>
+                              </th>
+                            )
+                          }
+                        })
+                      })()}
+                    </DataTable.TableRow>
+                  </DataTable.TableHead>
+                  <DataTable.TableBody>
+                    {rows.map(row => (
+                      <DataTable.TableRow key={row.id}>
+                        {(() => {
+                          return row.cells.map(cell => (
+                            <DataTable.TableCell key={cell.id}>{cell.value}</DataTable.TableCell>
+                          ))
+                        })()}
+                      </DataTable.TableRow>
+                    ))}
+                  </DataTable.TableBody>
+                </DataTable.Table>
+              </DataTable.TableContainer>
+              <PaginationV2
+                key='pagination'
+                id='resource-table-pagination'
+                onChange={changeTablePage}
+                pageSize={pageSize || PAGE_SIZES.DEFAULT}
+                page={pageNumber}
+                pageSizes={PAGE_SIZES.VALUES}
+                totalItems={totalNumberOfRows}
+                isLastPage={false}
+                itemsPerPageText={msgs.get('pagination.itemsPerPage')}
+                pageRangeText={(current, total) => msgs.get('pagination.pageRange', [current, total])}
+                itemRangeText={(min, max, total) => `${msgs.get('pagination.itemRange', [min, max])} ${msgs.get('pagination.itemRangeDescription', [total])}`}
+              />
+            </div>
+          )}
+        />
+      </div>
+    )
   }
 } // end of AppResourceTable component
 
+ResourceTable.propTypes = {
+  changeTablePage: PropTypes.func,
+  createNewModal: PropTypes.func,
+  existingSecrets: PropTypes.object,
+  filterItems: PropTypes.func,
+  handleSort: PropTypes.func,
+  headers: PropTypes.array,
+  namespace: PropTypes.string,
+  namespaces: PropTypes.array,
+  onInputChange: PropTypes.func,
+  pageNumber: PropTypes.number,
+  pageSize: PropTypes.number,
+  rows: PropTypes.array,
+  sortColumn: PropTypes.string,
+  sortDirection: PropTypes.string,
+  title: PropTypes.string,
+  totalNumberOfRows: PropTypes.number
+}
 
-
-export default ResourceTable;
+export default ResourceTable

--- a/src-web/components/kappnav/common/SecondaryHeader.jsx
+++ b/src-web/components/kappnav/common/SecondaryHeader.jsx
@@ -191,10 +191,9 @@ class SecondaryHeader extends React.Component {
 
   renderBreadCrumb() {
     const { breadcrumbItems } = this.props
-    return breadcrumbItems && breadcrumbItems.map((breadcrumb, index) => {
+    return breadcrumbItems && breadcrumbItems.map((breadcrumb) => {
       return (
-        // eslint-disable-next-line react/no-array-index-key
-        <div key={`${breadcrumb}-${index}`} className='bx--breadcrumb-item' title={decodeURIComponent(breadcrumb.label)}>
+        <div key={`${breadcrumb}-${breadcrumb.label}`} className='bx--breadcrumb-item' title={decodeURIComponent(breadcrumb.label)}>
           <a href={breadcrumb.url} className='bx--link'>{decodeURIComponent(breadcrumb.label)}</a>
         </div>
       )

--- a/src-web/components/kappnav/common/SecondaryHeader.jsx
+++ b/src-web/components/kappnav/common/SecondaryHeader.jsx
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,9 +25,9 @@ import ResourceModal from '../modals/ResourceModal'
 import RemoveResourceModal from '../modals/RemoveResourceModal'
 import ActionModal from '../modals/ActionModal'
 import ActionMessageModal from '../modals/ActionMessageModal'
-import {CONTEXT_PATH} from '../../../actions/constants';
 import msgs from '../../../../nls/kappnav.properties'
 import LeftNav from '../../LeftNav'
+import PropTypes from 'prop-types'
 
 require('../../../../scss/header.scss')
 require('../../../../scss/secondary-header.scss')
@@ -61,8 +61,8 @@ class SecondaryHeader extends React.Component {
       resourceModalSubmitUrl: '',
       resourceModalData: {
       }
-    };
-    window.secondaryHeader = this;
+    }
+    window.secondaryHeader = this
   }
 
   componentDidMount() {
@@ -79,89 +79,89 @@ class SecondaryHeader extends React.Component {
 
     // https://www.npmjs.com/package/hamburgers
     const hamburgerButton = (
-      <button className={'hamburger hamburger--slider ' + (leftNavOpen ? 'is-active' : '')} 
-              id='hamburger' aria-label={msgs.get('header.menu.label')} 
-              onClick={this.handleMenuClick} title={msgs.get('header.menu.label')}>
+      <button className={'hamburger hamburger--slider ' + (leftNavOpen ? 'is-active' : '')}
+        id='hamburger' aria-label={msgs.get('header.menu.label')}
+        onClick={this.handleMenuClick} title={msgs.get('header.menu.label')}>
 
         <span className="hamburger-box">
           <span className="hamburger-inner"></span>
         </span>
-        
       </button>
     )
 
     return (
       <div>
-        <LeftNav handleMenuClick={this.handleMenuClick} open={this.state.leftNavOpen}/>
+        <LeftNav handleMenuClick={this.handleMenuClick} open={this.state.leftNavOpen} />
         <div className="app-header app-header__container secondary" role="banner" aria-label={msgs.get('kappnav')}>
           <div className="app-menu-btn-container">
             {hamburgerButton}
           </div>
           {(() => {
-              return (
-                <div className='logo-container'>
-                  <div className='logo' style={{color: 'white', fontWeight:'bold'}}>
+            return (
+              <div className='logo-container'>
+                <div className='logo' style={{color: 'white', fontWeight:'bold'}}>
                     Kubernetes Application Navigator
-                  </div>
                 </div>
-              )
+              </div>
+            )
           })()}
           <div className="navigation-container"></div>
         </div>
-      {(() => {
-        if( (tabs && tabs.length > 0) || (breadcrumbItems && breadcrumbItems.length > 0) ) {
-          return (
-            <div className={'secondary-header-wrapper ' + primaryHeaderClasses} role='region' aria-label={title}>
-              <div className={`secondary-header ${simpleHeaderClasses}`} ref={div => this.secondaryHeader = div}>
-                {tabs && tabs.length > 0 ? (
-                  <DetailPageHeader hasTabs={true} role="" title={decodeURIComponent(title)} aria-label={`${title} ${msgs.get('secondaryHeader')}`}>
-                    <Breadcrumb>
-                      {breadcrumbItems && this.renderBreadCrumb()}
-                    </Breadcrumb>
-                    <Tabs selected={this.getSelectedTab() || 0} aria-label={`${title} ${msgs.get('tabs.label')}`}>
-                      {this.renderTabs()}
-                    </Tabs>
-                  </DetailPageHeader>
-                ) : (
-                  <DetailPageHeader hasTabs={true} statusColor={this.state.statusColor} statusText={this.state.statusText} title={decodeURIComponent(title)} aria-label={`${title} ${msgs.get('secondaryHeader')}`}>
-                    <Breadcrumb>
-                      {this.renderBreadCrumb()}
-                    </Breadcrumb>
-                    {this.state.actions}
-                  </DetailPageHeader>
-                )}
+        {(() => {
+          if( (tabs && tabs.length > 0) || (breadcrumbItems && breadcrumbItems.length > 0) ) {
+            return (
+              <div className={'secondary-header-wrapper ' + primaryHeaderClasses} role='region' aria-label={title}>
+                <div className={`secondary-header ${simpleHeaderClasses}`} ref={div => this.secondaryHeader = div}>
+                  {tabs && tabs.length > 0 ? (
+                    // eslint-disable-next-line jsx-a11y/aria-role
+                    <DetailPageHeader hasTabs={true} role="" title={decodeURIComponent(title)} aria-label={`${title} ${msgs.get('secondaryHeader')}`}>
+                      <Breadcrumb>
+                        {breadcrumbItems && this.renderBreadCrumb()}
+                      </Breadcrumb>
+                      <Tabs selected={this.getSelectedTab() || 0} aria-label={`${title} ${msgs.get('tabs.label')}`}>
+                        {this.renderTabs()}
+                      </Tabs>
+                    </DetailPageHeader>
+                  ) : (
+                    <DetailPageHeader hasTabs={true} statusColor={this.state.statusColor} statusText={this.state.statusText} title={decodeURIComponent(title)} aria-label={`${title} ${msgs.get('secondaryHeader')}`}>
+                      <Breadcrumb>
+                        {this.renderBreadCrumb()}
+                      </Breadcrumb>
+                      {this.state.actions}
+                    </DetailPageHeader>
+                  )}
+                </div>
               </div>
-            </div>
-          )
-        } else {
-          return (
-            <div className={'secondary-header-wrapper-min ' + primaryHeaderClasses} role='region' aria-label={`${title} ${msgs.get('secondaryHeader')}`}>
-              <div className={'secondary-header simple-header ' + simpleHeaderClasses}>
-                <h1 className='bx--detail-page-header-title'>{decodeURIComponent(title)}</h1>
+            )
+          } else {
+            return (
+              <div className={'secondary-header-wrapper-min ' + primaryHeaderClasses} role='region' aria-label={`${title} ${msgs.get('secondaryHeader')}`}>
+                <div className={'secondary-header simple-header ' + simpleHeaderClasses}>
+                  <h1 className='bx--detail-page-header-title'>{decodeURIComponent(title)}</h1>
+                </div>
               </div>
-            </div>
-          )
-        }
-      })()}
-      <ResourceModal open={this.state.resourceModalOpen}
-                     label={this.state.resourceModalLabel}
-                     editorMode='json'
-                     data={this.state.resourceModalData}
-                     submitUrl={this.state.resourceModalSubmitUrl}
-                     handleClose={(refresh, originalResource, newResource)=>{
-                       if(refresh===true && this.refreshCallback) { 
-                         this.refreshCallback({operation:"edit", originalResource:originalResource, newResource:newResource});
-                       }
-                       this.setState({resourceModalOpen:false})
-                     }}
-      />
+            )
+          }
+        })()}
+        <ResourceModal open={this.state.resourceModalOpen}
+          label={this.state.resourceModalLabel}
+          editorMode='json'
+          data={this.state.resourceModalData}
+          submitUrl={this.state.resourceModalSubmitUrl}
+          handleClose={(refresh, originalResource, newResource)=>{
+            if(refresh===true && this.refreshCallback) {
+              this.refreshCallback({operation:'edit', originalResource:originalResource, newResource:newResource})
+            }
+            this.setState({resourceModalOpen:false})
+          }}
+        />
         <RemoveResourceModal open={this.state.removeResourceModalOpen}
           label={this.state.resourceModalLabel}
           data={this.state.resourceModalData}
           submitUrl={this.state.resourceModalSubmitUrl}
           handleClose={(refresh) => {
             if (refresh === true && this.refreshCallback) {
-              this.refreshCallback({ operation: "delete", "name": this.state.resourceModalData.metadata.name });
+              this.refreshCallback({ operation: 'delete', 'name': this.state.resourceModalData.metadata.name })
             }
             this.setState({ removeResourceModalOpen: false })
           }}
@@ -185,7 +185,7 @@ class SecondaryHeader extends React.Component {
             this.setState({ actionMessageModalOpen: false })
           }}
         />
-    </div>
+      </div>
     )
   }
 
@@ -193,6 +193,7 @@ class SecondaryHeader extends React.Component {
     const { breadcrumbItems } = this.props
     return breadcrumbItems && breadcrumbItems.map((breadcrumb, index) => {
       return (
+        // eslint-disable-next-line react/no-array-index-key
         <div key={`${breadcrumb}-${index}`} className='bx--breadcrumb-item' title={decodeURIComponent(breadcrumb.label)}>
           <a href={breadcrumb.url} className='bx--link'>{decodeURIComponent(breadcrumb.label)}</a>
         </div>
@@ -220,9 +221,6 @@ class SecondaryHeader extends React.Component {
     return selectedTab[0] && selectedTab[0].index
   }
 
-  clickTab(url) {
-  }
-
   handleKeyDown(e) {
     e.persist()
     e.which === 32 && this.props.history.push(e.target.pathname)
@@ -234,31 +232,32 @@ class SecondaryHeader extends React.Component {
   }
 
   showResourceModal(open, label, data, submitUrl){
-    this.setState({resourceModalOpen:open, resourceModalLabel:label, resourceModalData:data, resourceModalSubmitUrl:submitUrl});
+    this.setState({resourceModalOpen:open, resourceModalLabel:label, resourceModalData:data, resourceModalSubmitUrl:submitUrl})
   }
 
   showRemoveResourceModal(open, label, data, submitUrl){
-    this.setState({removeResourceModalOpen:open, resourceModalLabel:label, resourceModalData:data, resourceModalSubmitUrl:submitUrl});
+    this.setState({removeResourceModalOpen:open, resourceModalLabel:label, resourceModalData:data, resourceModalSubmitUrl:submitUrl})
   }
 
   showActionResourceModal(open, label, data, submitUrl, input, cmd){
     var submitNoInput = true
     if(input && input.fields){
-      submitNoInput = false;
+      submitNoInput = false
     }
-    this.setState({actionModalOpen:open, resourceModalLabel:label, resourceModalData:data, resourceModalSubmitUrl:submitUrl, actionModalInput:input, submitNoInput:submitNoInput, submitCmd:cmd});
+    this.setState({actionModalOpen:open, resourceModalLabel:label, resourceModalData:data, resourceModalSubmitUrl:submitUrl, actionModalInput:input, submitNoInput:submitNoInput, submitCmd:cmd})
   }
 
   showActionMessageModal(open, result, error){
-    this.setState({actionMessageModalOpen:open, actionResult:result, actionError:error});
+    this.setState({actionMessageModalOpen:open, actionResult:result, actionError:error})
   }
 
   update(statusColor, statusText, actions){
-    this.setState({statusColor: statusColor, statusText: statusText, actions: actions});
+    this.setState({statusColor: statusColor, statusText: statusText, actions: actions})
   }
 
   handleMenuClick() {
     this.setState({
+      // eslint-disable-next-line react/no-access-state-in-setstate
       leftNavOpen: !this.state.leftNavOpen
     }, () => {
       if (this.state.leftNavOpen) {
@@ -277,6 +276,15 @@ class SecondaryHeader extends React.Component {
     document.removeEventListener('click', this.handleMouseClick)
   }
 
+}
+
+SecondaryHeader.propTypes = {
+  breadcrumbItems: PropTypes.array,
+  headerClasses: PropTypes.string,
+  history: PropTypes.object,
+  location: PropTypes.object,
+  tabs: PropTypes.array,
+  title: PropTypes.string
 }
 
 export default SecondaryHeader

--- a/src-web/components/kappnav/common/StructuredListModule.js
+++ b/src-web/components/kappnav/common/StructuredListModule.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,10 +21,11 @@
 require('../../../../scss/structured-list.scss')
 import React from 'react'
 import { Module, ModuleBody } from 'carbon-addons-cloud-react'
-import { StructuredListWrapper, StructuredListHead, StructuredListRow, StructuredListCell, StructuredListBody, OverflowMenu } from 'carbon-components-react'
+import { StructuredListWrapper, StructuredListHead, StructuredListRow, StructuredListCell, StructuredListBody} from 'carbon-components-react'
 import msgs from '../../../../nls/kappnav.properties'
 import { transform } from '../../../actions/common'
 import { Link } from 'react-router-dom'
+import PropTypes from 'prop-types'
 
 class StructuredListModule extends React.PureComponent {
 
@@ -42,18 +43,18 @@ class StructuredListModule extends React.PureComponent {
       rows,
       data,
       url,
-      id,
-      actions,
-      getResourceAction,
-      navRoutes
+      id
     } = this.props
 
-    const ariaLabel = msgs.get(title, [data.kind])
+    //const ariaLabel = msgs.get(title, [data.kind])
 
     return (<Module className={this.state.expanded ? 'structured-list-module' : 'structured-list-module collapsedModule' } id={id}>
+      {/* esl failures for line between disable and enable: jsx-a11y/click-events-have-key-events and jsx-a11y/no-static-element-interactions */}
+      {/* eslint-disable */}
       <div className='bx--module__header' style={{justifyContent: 'space-between'}} onClick={()=>{this.toggleExpandCollapse()}}>
+      {/* eslint-enable */}
         <ul data-accordion className="bx--accordion">
-          <li data-accordion-item className="bx--accordion__item" className={this.state.expanded ? 'bx--accordion__item--active' : '' }>
+          <li data-accordion-item className={this.state.expanded ? 'bx--accordion__item--active' : '' }>
             <button className="bx--accordion__heading" aria-expanded={this.state.expanded} aria-controls={id+'modulePane'} title={this.state.expanded ? msgs.get('collapse') : msgs.get('expand') }>
               <svg className="bx--accordion__arrow" width="7" height="12" viewBox="0 0 7 12">
                 <path fillRule="nonzero" d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z" />
@@ -68,6 +69,7 @@ class StructuredListModule extends React.PureComponent {
           <StructuredListHead>
             <StructuredListRow head>
               {headerRows.map((row, index) =>
+                // eslint-disable-next-line react/no-array-index-key
                 <StructuredListCell head key={index}>
                   {msgs.get(row)}
                 </StructuredListCell>
@@ -76,8 +78,10 @@ class StructuredListModule extends React.PureComponent {
           </StructuredListHead>
           <StructuredListBody>
             {rows.map((row, index) =>
+              // eslint-disable-next-line react/no-array-index-key
               <StructuredListRow key={index}>
                 {row.cells.map((cell, index) =>
+                  // eslint-disable-next-line react/no-array-index-key
                   <StructuredListCell key={index}>
                     <p title={transform(data, cell)}>{cell.link && url ? <Link to={url} className='bx--link'>{transform(data, cell)}</Link> : transform(data, cell)}</p>
                   </StructuredListCell>
@@ -91,8 +95,19 @@ class StructuredListModule extends React.PureComponent {
   }
 
   toggleExpandCollapse(){
+    // eslint-disable-next-line react/no-access-state-in-setstate
     this.setState({expanded: !this.state.expanded})
   }
+}
+
+StructuredListModule.propTypes = {
+  data: PropTypes.object,
+  expanded: PropTypes.bool,
+  headerRows: PropTypes.array,
+  id: PropTypes.string,
+  rows: PropTypes.array,
+  title: PropTypes.string,
+  url: PropTypes.string
 }
 
 export default StructuredListModule

--- a/src-web/components/kappnav/common/StructuredListModule.js
+++ b/src-web/components/kappnav/common/StructuredListModule.js
@@ -68,9 +68,8 @@ class StructuredListModule extends React.PureComponent {
         <StructuredListWrapper className='bx--structured-list--condensed' ariaLabel={msgs.get(title, [data.kind])}>
           <StructuredListHead>
             <StructuredListRow head>
-              {headerRows.map((row, index) =>
-                // eslint-disable-next-line react/no-array-index-key
-                <StructuredListCell head key={index}>
+              {headerRows.map((row) =>
+                <StructuredListCell head key={msgs.get(row)}>
                   {msgs.get(row)}
                 </StructuredListCell>
               )}
@@ -80,9 +79,8 @@ class StructuredListModule extends React.PureComponent {
             {rows.map((row, index) =>
               // eslint-disable-next-line react/no-array-index-key
               <StructuredListRow key={index}>
-                {row.cells.map((cell, index) =>
-                  // eslint-disable-next-line react/no-array-index-key
-                  <StructuredListCell key={index}>
+                {row.cells.map((cell) =>
+                  <StructuredListCell key={transform(data, cell)}>
                     <p title={transform(data, cell)}>{cell.link && url ? <Link to={url} className='bx--link'>{transform(data, cell)}</Link> : transform(data, cell)}</p>
                   </StructuredListCell>
                 )}

--- a/src-web/components/kappnav/modals/ActionMessageModal.js
+++ b/src-web/components/kappnav/modals/ActionMessageModal.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ import { ComposedModal, ModalHeader, ModalBody, ModalFooter } from 'carbon-compo
 import {CONTEXT_PATH} from '../../../actions/constants'
 import { withRouter } from 'react-router-dom'
 import msgs from '../../../../nls/kappnav.properties'
-
+import PropTypes from 'prop-types'
 
 class ActionMessageModal extends React.PureComponent {
 
@@ -49,7 +49,7 @@ class ActionMessageModal extends React.PureComponent {
 
   render() {
     const { open, label, handleClose, result, error } = this.props
-    
+
     if(error) {
       //Failed to submit action without inputs (ie, we didn't pop up a dialog, we just submitted right away).
       //In this case there is no dialog to display errors on, so we will show the error here.
@@ -61,7 +61,8 @@ class ActionMessageModal extends React.PureComponent {
           selectorPrimaryFocus='.bx--modal-close'
           aria-label={'Label'}
           open={open}>
-           <ModalHeader buttonOnClick={handleClose}>
+          <ModalHeader buttonOnClick={handleClose}>
+            {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
             <h4 className="bx--modal-header__label"></h4>
             <h2 className="bx--modal-header__heading">{label.label}</h2>
           </ModalHeader>
@@ -69,7 +70,7 @@ class ActionMessageModal extends React.PureComponent {
 
             {msgs.get('job.failure', [error])}
 
-  
+
           </ModalBody>
         </ComposedModal>
       )
@@ -94,10 +95,18 @@ class ActionMessageModal extends React.PureComponent {
         </ComposedModal>
       )
     } else {
-      return (<div/>)
+      return (<div />)
     }
-    
+
   }
+}
+
+ActionMessageModal.propTypes = {
+  error: PropTypes.object,
+  handleClose: PropTypes.func,
+  label: PropTypes.object,
+  open: PropTypes.string,
+  result: PropTypes.object
 }
 
 export default withRouter(ActionMessageModal)

--- a/src-web/components/kappnav/modals/ActionMessageModal.js
+++ b/src-web/components/kappnav/modals/ActionMessageModal.js
@@ -18,14 +18,14 @@
 
 'use strict'
 
-import React from 'react'
+import React, {Component} from 'react'
 import { ComposedModal, ModalHeader, ModalBody, ModalFooter } from 'carbon-components-react'
 import {CONTEXT_PATH} from '../../../actions/constants'
 import { withRouter } from 'react-router-dom'
 import msgs from '../../../../nls/kappnav.properties'
 import PropTypes from 'prop-types'
 
-class ActionMessageModal extends React.PureComponent {
+class ActionMessageModal extends Component {
 
   constructor (props){
     super(props)

--- a/src-web/components/kappnav/modals/ActionModal.js
+++ b/src-web/components/kappnav/modals/ActionModal.js
@@ -160,7 +160,7 @@ export const transform = (field, optional, handleChange, event) => {
   handleChange(field, optional, event.target.value)
 }
 
-class ActionModal extends React.PureComponent {
+class ActionModal extends React.Component {
 
   constructor (props){
     super(props)
@@ -215,8 +215,7 @@ class ActionModal extends React.PureComponent {
             selectorPrimaryFocus='.bx--modal-close'
             aria-label={msgs.get(label.heading)}>
             {reqErrorMsg && reqErrorMsg.length > 0 &&
-              // eslint-disable-next-line react/no-array-index-key
-              reqErrorMsg.map((err,key) => <InlineNotification key={key} kind='error' title='' subtitle={err} iconDescription={msgs.get('svg.description.error')} />)
+              reqErrorMsg.map((err) => <InlineNotification key={err.id} kind='error' title='' subtitle={err} iconDescription={msgs.get('svg.description.error')} />)
             }
             <div>
               <Form>
@@ -245,8 +244,7 @@ class ActionModal extends React.PureComponent {
                           hideLabel
                           onChange={transform.bind(null, field.name, field.optional, onChange)}
                         >
-                          {/* eslint-disable-next-line react/no-array-index-key */}
-                          {field.values.map((value, index) => <SelectItem key={index} text={value} value={value} />)}
+                          {field.values.map((value) => <SelectItem key={value.id} text={value} value={value} />)}
                         </Select>
                       </FieldWrapper>
                     )

--- a/src-web/components/kappnav/modals/ApplicationModal.js
+++ b/src-web/components/kappnav/modals/ApplicationModal.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ import React from 'react'
 import msgs from '../../../../nls/kappnav.properties'
 import NavModal, { withForm } from './NavModal'
 import { General, Labels, Namespace, MatchLabels, MatchExpressions, ComponentKinds } from '../common/ModalFormItems'
+import PropTypes from 'prop-types'
 
 const MENU_ITEMS = [
   'general',
@@ -56,7 +57,7 @@ const applicationMapping = {
 
 const formMapping = Object.assign(applicationMapping)
 
-const Selector = ({form, onChange}, context) =>
+const Selector = ({form, onChange}) =>
   <div>
     <MatchLabels
       type='matchLabels'
@@ -70,7 +71,12 @@ const Selector = ({form, onChange}, context) =>
       addLabel={msgs.get('formaction.addMatchExpression')} />
   </div>
 
-const KindSection = ({form, onChange}, context) =>
+Selector.propTypes = {
+  form: PropTypes.object,
+  onChange: PropTypes.func
+}
+
+const KindSection = ({form, onChange}) =>
   <div>
     <ComponentKinds
       type='componentKinds'
@@ -79,7 +85,12 @@ const KindSection = ({form, onChange}, context) =>
       addLabel={msgs.get('formaction.addKind')} />
   </div>
 
-const ApplicationModal = ({ createAction, namespaces, form, onChange, onJsonChange, json, onToggle }, context) =>
+KindSection.propTypes = {
+  form: PropTypes.object,
+  onChange: PropTypes.func
+}
+
+const ApplicationModal = ({ createAction, namespaces, form, onChange, onJsonChange, json, onToggle }) =>
   <NavModal
     form={form}
     buttonName={msgs.get('button.application.create')}
@@ -104,5 +115,15 @@ const ApplicationModal = ({ createAction, namespaces, form, onChange, onJsonChan
     <Selector form={form} />
     <KindSection form={form} />
   </NavModal>
+
+ApplicationModal.propTypes = {
+  createAction: PropTypes.func,
+  form: PropTypes.object,
+  json: PropTypes.string,
+  namespaces: PropTypes.array,
+  onChange: PropTypes.func,
+  onJsonChange: PropTypes.func,
+  onToggle: PropTypes.func
+}
 
 export default withForm(ApplicationModal, initialState)

--- a/src-web/components/kappnav/modals/NavModal.js
+++ b/src-web/components/kappnav/modals/NavModal.js
@@ -460,9 +460,8 @@ class NavModalForm extends React.PureComponent {
 
   getMenuItems() {
     const { menuItems, onMenuClick, validationErrors } = this.props
-    return menuItems.map((item, index) =>
-      // eslint-disable-next-line react/no-array-index-key
-      <li key={index} className={this.isActive(item)} id={item}>
+    return menuItems.map((item) =>
+      <li key={`${item}-${item.id}`} className={this.isActive(item)} id={item}>
         <a href="#" onClick={onMenuClick.bind(null, item)} className='menu-item' role='menuitem'>{msgs.get(`modal.nav.${item}`)}</a>
         {validationErrors.form && validationErrors[item] && !this.isActive(item) && <Icon className='modal-tab-error' name='icon--error--glyph' description={msgs.get('svg.description.error')} />}
       </li>

--- a/src-web/components/kappnav/modals/NavModal.js
+++ b/src-web/components/kappnav/modals/NavModal.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,6 +33,7 @@ import msgs from '../../../../nls/kappnav.properties'
 import {REQUEST_STATUS} from '../../../actions/constants'
 import lodash from 'lodash'
 import handleKeyboardEvent from '../../../util/accessibility'
+import PropTypes from 'prop-types'
 
 require('../../../../scss/modal.scss')
 
@@ -55,19 +56,23 @@ const withForm = (Component, initialForm) => {
 
       //These are hacks because I could not find a good way to initialize a Select input box's form value from a dynamic list. Only
       //can hard code it as a static string.
+      // eslint-disable-next-line react/prop-types
       if(!form.namespace && this.props.namespace) form.namespace = this.props.namespace
+      // eslint-disable-next-line react/prop-types
       if(!form.selectedSecret && this.props.existingSecrets && this.props.existingSecrets[0]) {
+        // eslint-disable-next-line react/prop-types
         form.selectedSecret = this.props.existingSecrets[0].Name
       }
 
-      return <Component {...this.props} onChange={this.onChange} form={form} onJsonChange={this.onJsonChange} onToggle={this.onToggle} json={json}/>
+      return <Component {...this.props} onChange={this.onChange} form={form} onJsonChange={this.onJsonChange} onToggle={this.onToggle} json={json} />
     }
 
     onChange(fields, values) {
       if (arguments.length == 0) {
         this.setState(lodash.cloneDeep(initialForm))
       } else {
-        let form = Object.assign({}, this.state.form)
+        // eslint-disable-next-line react/no-access-state-in-setstate
+        const form = Object.assign({}, this.state.form)
 
         if(Array.isArray(fields)) {
           for(var i=0; i<fields.length; i++)
@@ -75,7 +80,7 @@ const withForm = (Component, initialForm) => {
         } else {
           lodash.set(form, fields, values)
         }
-        
+
 
         this.setState({form})
       }
@@ -131,41 +136,41 @@ class NavModal extends React.PureComponent {
     const {open, jsonMode, selectedMenuItem, parsingError, validationErrors} = this.state
 
     return (<div>
-      <Button small icon={'add--glyph'} onClick={this.handleOpen.bind(this, true)} disabled={this.props.disabled} iconDescription={msgs.get('svg.description.plus')} id={`create-application`}>
+      <Button small icon={'add--glyph'} onClick={this.handleOpen.bind(this, true)} disabled={this.props.disabled} iconDescription={msgs.get('svg.description.plus')} id={'create-application'}>
         {this.props.buttonName}
       </Button>
       {
         open && <ComposedModal id='nav-modal' selectorPrimaryFocus='.bx--modal-close' className='modal nav-modal' role='region' aria-label={this.props.modalHeading} open={open} onClose={() => this.toggleModal(false)}>
-            <ModalHeader buttonOnClick={this.handleOpen.bind(this, false)} iconDescription={this.props.closeButtonLabel}>
-              <div>
-                <p className='bx--modal-header__label'>
-                  {this.props.modalLabel}
+          <ModalHeader buttonOnClick={this.handleOpen.bind(this, false)} iconDescription={this.props.closeButtonLabel}>
+            <div>
+              <p className='bx--modal-header__label'>
+                {this.props.modalLabel}
+              </p>
+              <p className='bx--modal-header__heading'>
+                {this.props.modalHeading}
+              </p>
+            </div>
+            {
+              !hideJsonEditor && <div className='toggle'>
+                <p>
+                  {msgs.get('mode.json')}
                 </p>
-                <p className='bx--modal-header__heading'>
-                  {this.props.modalHeading}
-                </p>
+                <Toggle id='json-toggle' onToggle={this.handleToggle} labelA={msgs.get('off')} labelB={msgs.get('on')} />
               </div>
-              {
-                !hideJsonEditor && <div className='toggle'>
-                    <p>
-                      {msgs.get('mode.json')}
-                    </p>
-                    <Toggle id='json-toggle' onToggle={this.handleToggle} labelA={msgs.get('off')} labelB={msgs.get('on')}/>
-                  </div>
-              }
-            </ModalHeader>
-            <ModalBody>
-              {
-                jsonMode
-                  ? <NavModalJsonEditor postStatus={this.state.postStatus} postErrorMsg={this.state.postErrorMsg} parsingError={parsingError} json={json} onJsonChange={onJsonChange}/>
-                  : <NavModalForm postStatus={this.state.postStatus} postErrorMsg={this.state.postErrorMsg} parsingError={parsingError} menuItems={menuItems} selectedMenuItem={selectedMenuItem} onMenuClick={this.onMenuClick} childComponents={children} validationErrors={validationErrors} onChange={onChange}/>
-              }
-            </ModalBody>
-            <ModalFooter primaryButtonDisabled={this.props.primaryButtonDisabled} primaryButtonText={msgs.get(
-                this.props.modalButtonName
-                ? this.props.modalButtonName
-                : 'modal.button.create')} secondaryButtonText={msgs.get('modal.button.cancel')} onRequestClose={this.handleOpen.bind(this, false)} onRequestSubmit={this.handleSubmit.bind(this)}/>
-          </ComposedModal>
+            }
+          </ModalHeader>
+          <ModalBody>
+            {
+              jsonMode
+                ? <NavModalJsonEditor postStatus={this.state.postStatus} postErrorMsg={this.state.postErrorMsg} parsingError={parsingError} json={json} onJsonChange={onJsonChange} />
+                : <NavModalForm postStatus={this.state.postStatus} postErrorMsg={this.state.postErrorMsg} parsingError={parsingError} menuItems={menuItems} selectedMenuItem={selectedMenuItem} onMenuClick={this.onMenuClick} childComponents={children} validationErrors={validationErrors} onChange={onChange} />
+            }
+          </ModalBody>
+          <ModalFooter primaryButtonDisabled={this.props.primaryButtonDisabled} primaryButtonText={msgs.get(
+            this.props.modalButtonName
+              ? this.props.modalButtonName
+              : 'modal.button.create')} secondaryButtonText={msgs.get('modal.button.cancel')} onRequestClose={this.handleOpen.bind(this, false)} onRequestSubmit={this.handleSubmit.bind(this)} />
+        </ComposedModal>
       }
     </div>)
   }
@@ -187,9 +192,9 @@ class NavModal extends React.PureComponent {
   }
 
   convertToForm() {
-    const {json, formMapping, onToggle, resourceType} = this.props
+    const {json, formMapping, onToggle} = this.props
     const jsonData = Object.assign({}, JSON.parse(json))
-    let formData = lodash.mapValues(formMapping, field => lodash.get(jsonData, field))
+    const formData = lodash.mapValues(formMapping, field => lodash.get(jsonData, field))
     // Empty array values should contain empty string for form
     const arrayVals = Object.keys(this.props.initialForm.form).filter(key => lodash.isArray(this.props.initialForm.form[key]) && KEY_VALUE_PAIRS.indexOf(key) === -1)
     arrayVals.forEach((key) => {
@@ -204,20 +209,20 @@ class NavModal extends React.PureComponent {
     keyValuePairs && keyValuePairs.forEach(pair => {
       const currentVal = formData[pair]
 
-        formData[pair] = lodash.isEmpty(currentVal)
-          ? [
-            {
-              name: '',
-              value: ''
-            }
-          ]
-          : Object.keys(currentVal).map(key => ({name: key, value: currentVal[key]}))
+      formData[pair] = lodash.isEmpty(currentVal)
+        ? [
+          {
+            name: '',
+            value: ''
+          }
+        ]
+        : Object.keys(currentVal).map(key => ({name: key, value: currentVal[key]}))
     })
 
     // Reformat componentKinds array
     if (lodash.has(formData, 'componentKinds')) {
       const componentKinds = formData.componentKinds
-      formData.componentKinds = componentKinds && componentKinds.map((kind, index) => {
+      formData.componentKinds = componentKinds && componentKinds.map((kind) => {
         return {
           group: kind.group,
           kind: kind.kind
@@ -261,7 +266,7 @@ class NavModal extends React.PureComponent {
   handleSubmit() {
     var errorCallback = function(error) {
       this.setState({postStatus: REQUEST_STATUS.ERROR, postErrorMsg: error})
-    }.bind(this);
+    }.bind(this)
 
     const {createAction, json, formMapping, hideJsonEditor} = this.props
     try {
@@ -286,7 +291,7 @@ class NavModal extends React.PureComponent {
 
   formatJson() {
     let mergedData
-    const {formMapping, json, form, resourceType} = this.props
+    const {formMapping, json, form} = this.props
     const templateName = form && form.kind && form.kind.toLowerCase()
     const jsonFormData = JSON.parse(this.parseTemplate(templateName, this.pruneFormData()))
 
@@ -318,8 +323,8 @@ class NavModal extends React.PureComponent {
   }
 
   pruneFormData() {
-    const {form, resourceType} = this.props
-    let formData = {}
+    const {form} = this.props
+    const formData = {}
     lodash.forIn(form, (value, formKey) => {
       if (lodash.isArray(value))
         if (formKey === 'matchExpressions') {
@@ -330,7 +335,7 @@ class NavModal extends React.PureComponent {
           })
         } else
           formData[formKey] = lodash.compact(value).filter(item => lodash.every(item, value => value !== ''))
-    else
+      else
         formData[formKey] = value
     })
     return formData
@@ -365,6 +370,29 @@ class NavModal extends React.PureComponent {
   }
 }
 
+NavModal.propTypes = {
+  buttonName: PropTypes.string,
+  children: PropTypes.array,
+  closeButtonLabel: PropTypes.string,
+  createAction: PropTypes.func,
+  disabled: PropTypes.object,
+  form: PropTypes.object,
+  formMapping: PropTypes.object,
+  hideJsonEditor: PropTypes.bool,
+  initialForm: PropTypes.object,
+  json: PropTypes.string,
+  menuItems: PropTypes.array,
+  modalButtonName: PropTypes.string,
+  modalHeading: PropTypes.string,
+  modalLabel: PropTypes.string,
+  onChange: PropTypes.func,
+  onJsonChange: PropTypes.func,
+  onToggle: PropTypes.func,
+  primaryButtonDisabled: PropTypes.object,
+  selectedNamespace: PropTypes.string,
+  validate: PropTypes.func
+}
+
 const AceEditor = (props) => {
   if (typeof window !== 'undefined') {
     const Ace = require('react-ace').default
@@ -377,19 +405,20 @@ const AceEditor = (props) => {
 
 class IsomorphicEditor extends React.Component {
   constructor (props){
-    super(props);
+    super(props)
     this.state = { mounted: false }
   }
   componentDidMount() {
+    // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({ mounted: true })
   }
   render() {
     if(this.state.mounted){
-          return (
-            <AceEditor {...this.props} onLoad={this.addAriaLabelToAceCursor} setOptions={{showLineNumbers: false}}/>
-          )
+      return (
+        <AceEditor {...this.props} onLoad={this.addAriaLabelToAceCursor} setOptions={{showLineNumbers: false}} />
+      )
     }
-    return ( <div/>)
+    return ( <div />)
   }
 }
 
@@ -432,6 +461,7 @@ class NavModalForm extends React.PureComponent {
   getMenuItems() {
     const { menuItems, onMenuClick, validationErrors } = this.props
     return menuItems.map((item, index) =>
+      // eslint-disable-next-line react/no-array-index-key
       <li key={index} className={this.isActive(item)} id={item}>
         <a href="#" onClick={onMenuClick.bind(null, item)} className='menu-item' role='menuitem'>{msgs.get(`modal.nav.${item}`)}</a>
         {validationErrors.form && validationErrors[item] && !this.isActive(item) && <Icon className='modal-tab-error' name='icon--error--glyph' description={msgs.get('svg.description.error')} />}
@@ -451,6 +481,18 @@ class NavModalForm extends React.PureComponent {
 
     handleKeyboardEvent(e, data, 'nav-modal')
   }
+}
+
+NavModalForm.propTypes = {
+  childComponents: PropTypes.array,
+  menuItems: PropTypes.array,
+  onChange: PropTypes.func,
+  onMenuClick: PropTypes.func,
+  parsingError: PropTypes.bool,
+  postErrorMsg: PropTypes.string,
+  postStatus: PropTypes.string,
+  selectedMenuItem: PropTypes.string,
+  validationErrors: PropTypes.object
 }
 
 const NavModalJsonEditor = ({
@@ -488,6 +530,13 @@ const NavModalJsonEditor = ({
     />
   </div>
 
+NavModalJsonEditor.propTypes = {
+  json: PropTypes.string,
+  onJsonChange: PropTypes.func,
+  parsingError: PropTypes.bool,
+  postErrorMsg: PropTypes.string,
+  postStatus: PropTypes.string
+}
 export default NavModal
 export {
   withForm

--- a/src-web/components/kappnav/modals/RemoveResourceModal.js
+++ b/src-web/components/kappnav/modals/RemoveResourceModal.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,6 +24,7 @@ import msgs from '../../../../nls/kappnav.properties'
 import { withRouter } from 'react-router-dom'
 import { REQUEST_STATUS, RESOURCE_TYPES } from '../../../actions/constants'
 import { translateKind, getToken } from '../../../actions/common'
+import PropTypes from 'prop-types'
 
 class RemoveResourceModal extends React.PureComponent {
 
@@ -38,25 +39,27 @@ class RemoveResourceModal extends React.PureComponent {
       if(response.ok) {
         this.props.handleClose(true)
       } else {
+        // eslint-disable-next-line react/no-unused-state
         this.setState({reqErrorMsg: [response.status + ' ' + response.statusText]})
       }
-    }.bind(this);
+    }.bind(this)
 
     fetch(this.props.submitUrl, {
       method: 'DELETE',
       headers: {
-        "CSRF-Token": getToken()
+        'CSRF-Token': getToken()
       }
     })
       .then(response => deleteCallback(response))
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.reqStatus === REQUEST_STATUS.IN_PROGRESS && nextProps.reqStatus === REQUEST_STATUS.DONE)
       this.props.handleClose()
   }
 
   render() {
+    // eslint-disable-next-line no-unused-vars
     const { reqStatus, reqErrorMsg, open, label, data } = this.props
 
     var name = (data.metadata && data.metadata.name) ? data.metadata.name : ''
@@ -101,6 +104,16 @@ class RemoveResourceModal extends React.PureComponent {
       </div>
     )
   }
+}
+
+RemoveResourceModal.propTypes = {
+  data: PropTypes.object,
+  handleClose: PropTypes.func,
+  label: PropTypes.object,
+  open: PropTypes.bool,
+  reqErrorMsg: PropTypes.string,
+  reqStatus: PropTypes.string,
+  submitUrl: PropTypes.string
 }
 
 export default withRouter(RemoveResourceModal)

--- a/src-web/components/kappnav/modals/ResourceModal.js
+++ b/src-web/components/kappnav/modals/ResourceModal.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,7 @@ import msgs from '../../../../nls/kappnav.properties'
 import { REQUEST_STATUS, RESOURCE_TYPES } from '../../../actions/constants'
 import jsYaml from 'js-yaml'
 import { translateKind, getToken } from '../../../actions/common'
+import PropTypes from 'prop-types'
 
 require('../../../../scss/modal.scss')
 
@@ -45,10 +46,11 @@ class IsomorphicEditor extends React.Component {
     this.state = { mounted: false }
   }
   componentDidMount() {
+    // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({ mounted: true })
   }
   addAriaLabelToAceCursor() {
-    let element = document.querySelector('.ace_editor > textarea[class="ace_text-input"]')
+    const element = document.querySelector('.ace_editor > textarea[class="ace_text-input"]')
     element.setAttribute('aria-label', 'code editor cursor')
   }
   render() {
@@ -95,7 +97,7 @@ class ResourceModal extends React.PureComponent {
             cache: 'no-cache',
             headers: {
               'Content-Type': 'application/json; charset=utf-8',
-              "CSRF-Token": getToken()
+              'CSRF-Token': getToken()
             },
             body: JSON.stringify(resource),
           })
@@ -104,6 +106,7 @@ class ResourceModal extends React.PureComponent {
       } catch(e) {
         console.error(e) //eslint-disable-line no-console
         this.props.receivePostError(resourceType, {error: {message: e.message}})
+        // eslint-disable-next-line react/no-access-state-in-setstate
         this.setState({reqErrorMsg: [...this.state.reqErrorMsg, e.message]})
       }
     })
@@ -124,7 +127,7 @@ class ResourceModal extends React.PureComponent {
     this.setState({data: value})
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.data && this.props.data != nextProps.data) {
       if (nextProps.editorMode === 'json') {
         this.setState({data:JSON.stringify(nextProps.data, null, 2)})
@@ -134,6 +137,7 @@ class ResourceModal extends React.PureComponent {
       }
     }
     if (nextProps.reqStatus && nextProps.reqStatus === REQUEST_STATUS.ERROR) {
+      // eslint-disable-next-line react/no-access-state-in-setstate
       this.setState({ reqErrorMsg: [...this.state.reqErrorMsg, nextProps.reqErrorMsg]})
     }
     if (nextProps.reqCount === 0 && !nextProps.reqErrCount) {
@@ -144,16 +148,16 @@ class ResourceModal extends React.PureComponent {
   componentDidMount() {
 
     if (this.props.editorMode === 'json') {
+      // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({data: JSON.stringify(this.props.data, null, 2)})
     } else {
+      // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({data: jsYaml.dump(this.props.data)})
     }
   }
 
   render() {
     const { reqCount, open, label, editorMode } = this.props
-    let kindTranslated = translateKind(this.props.data.kind)
-
 
     let modalLabel, modalHeading
     let upperCaseKind = this.props.data.kind
@@ -195,6 +199,7 @@ class ResourceModal extends React.PureComponent {
           aria-label={modalHeading}>
           <div>
             {this.state.reqErrorMsg && this.state.reqErrorMsg.length > 0 &&
+              // eslint-disable-next-line react/no-array-index-key
               this.state.reqErrorMsg.map((err,key) => <InlineNotification key={key} kind='error' title='' subtitle={err} iconDescription={msgs.get('svg.description.error')} />)
             }
             <IsomorphicEditor
@@ -221,6 +226,21 @@ class ResourceModal extends React.PureComponent {
       </div>
     )
   }
+}
+
+ResourceModal.propTypes = {
+  data: PropTypes.object,
+  editorMode: PropTypes.string,
+  handleClose: PropTypes.func,
+  label: PropTypes.object,
+  open: PropTypes.bool,
+  receivePostError: PropTypes.func,
+  reqCount: PropTypes.object,
+  reqErrCount: PropTypes.bool,
+  reqErrorMsg: PropTypes.string,
+  reqStatus: PropTypes.string,
+  resourceType: PropTypes.object,
+  submitUrl: PropTypes.string
 }
 
 export default ResourceModal

--- a/src-web/components/kappnav/modals/ResourceModal.js
+++ b/src-web/components/kappnav/modals/ResourceModal.js
@@ -199,8 +199,7 @@ class ResourceModal extends React.PureComponent {
           aria-label={modalHeading}>
           <div>
             {this.state.reqErrorMsg && this.state.reqErrorMsg.length > 0 &&
-              // eslint-disable-next-line react/no-array-index-key
-              this.state.reqErrorMsg.map((err,key) => <InlineNotification key={key} kind='error' title='' subtitle={err} iconDescription={msgs.get('svg.description.error')} />)
+              this.state.reqErrorMsg.map((err) => <InlineNotification key={err.id} kind='error' title='' subtitle={err} iconDescription={msgs.get('svg.description.error')} />)
             }
             <IsomorphicEditor
               theme='monokai'

--- a/src-web/definitions/application.js
+++ b/src-web/definitions/application.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -339,8 +339,8 @@ export function getMatchExpressions(item) {
   })
 }
 
-export function getLink(itemName) {
-  return ``
+export function getLink() {
+  return ''
 }
 
 export function refreshApplication(appname, namespace, appNavConfigData, applicationResourceData) {
@@ -348,104 +348,104 @@ export function refreshApplication(appname, namespace, appNavConfigData, applica
     .then(response => {
       if (!response.ok) {
         // TODO: How do return a failure in a promise?
-        return null;
+        return null
       } else {
-        return response.json();
+        return response.json()
       }
     }).then(result => {
-      var metadata = result.metadata;
-      updateSecondaryHeader(getStatus(metadata, appNavConfigData).statusColor, getStatus(metadata, appNavConfigData).statusText, getOverflowMenu(result, undefined, applicationResourceData, undefined, undefined));
+      var metadata = result.metadata
+      updateSecondaryHeader(getStatus(metadata, appNavConfigData).statusColor, getStatus(metadata, appNavConfigData).statusText, getOverflowMenu(result, undefined, applicationResourceData, undefined, undefined))
       return result
-    });
+    })
 }
 
 export function refreshApplicationComponents(appname, namespace, appNavConfigData, applicationResourceData) {
   return fetch('/kappnav/components/' + encodeURIComponent(appname)+'?namespace='+encodeURIComponent(namespace))
-  .then(response => {
-    if (!response.ok) {
-      return null;
-    } else {
-      return response.json();
-    }
-  }).then(result => {
+    .then(response => {
+      if (!response.ok) {
+        return null
+      } else {
+        return response.json()
+      }
+    }).then(result => {
 
-    if (result) {
-      var rowArray = [];
-      result.components.forEach((item, index) => {
-        var component = item.component;
+      if (result) {
+        var rowArray = []
+        result.components.forEach((item, index) => {
+          var component = item.component
 
-        var metadata = component.metadata;
-        var annotations = metadata.annotations
-          ? metadata.annotations
-          : {};
-        var kind = component.kind;
-        var compositeKind = kind
-          ? kind
-          : '';
-        compositeKind = annotations && annotations[SUBKIND]
-          ? compositeKind + '.' + annotations[SUBKIND]
-          : compositeKind;
-        var platform = annotations[PLATFORM_KIND]
-          ? annotations[PLATFORM_KIND]
-          : 'Kube';
-        platform = platform && annotations[PLATFORM_NAME]
-          ? platform + '.' + annotations[PLATFORM_NAME]
-          : platform;
+          var metadata = component.metadata
+          var annotations = metadata.annotations
+            ? metadata.annotations
+            : {}
+          var kind = component.kind
+          var compositeKind = kind
+            ? kind
+            : ''
+          compositeKind = annotations && annotations[SUBKIND]
+            ? compositeKind + '.' + annotations[SUBKIND]
+            : compositeKind
+          var platform = annotations[PLATFORM_KIND]
+            ? annotations[PLATFORM_KIND]
+            : 'Kube'
+          platform = platform && annotations[PLATFORM_NAME]
+            ? platform + '.' + annotations[PLATFORM_NAME]
+            : platform
 
-        var itemObj = {};
-        var itemId = component.metadata.name + "_" + index;
-        itemObj.id = itemId;
-        itemObj.status = buildStatusHtml(getStatus(metadata, appNavConfigData));
+          var itemObj = {}
+          var itemId = component.metadata.name + '_' + index
+          itemObj.id = itemId
+          itemObj.status = buildStatusHtml(getStatus(metadata, appNavConfigData))
 
-        var resourceType = kind.toLocaleLowerCase();
+          var resourceType = kind.toLocaleLowerCase()
 
-        itemObj.compositeKind = compositeKind;
-        itemObj.kind = kind;
-        itemObj.namespace = component.metadata.namespace;
-        itemObj.platform = platform;
+          itemObj.compositeKind = compositeKind
+          itemObj.kind = kind
+          itemObj.namespace = component.metadata.namespace
+          itemObj.platform = platform
 
-        var actionMap = item["action-map"]
-        if (resourceType == "application") {  //known link to our detail panel and our custom resource types
-          itemObj.name = <a href="#" onClick={() => resourceType == "application" ? displayApp(metadata.name, metadata.namespace) : displayDetail(appname, resourceType, metadata.name, metadata.namespace)}>
-            {metadata.name}
-          </a>;
-          itemObj.menuAction = getOverflowMenu(component, actionMap, applicationResourceData, appname, namespace);
-        } else {
-          var urlActions = actionMap && actionMap["url-actions"];
-          var urlActions = urlActions && urlActions.filter(function (action) {
-            return action["name"]=="detail";
-          });
-
-          itemObj.menuAction = getOverflowMenu(component, actionMap, undefined, appname, namespace);  //custom actions
-
-          var link = urlActions && urlActions[0] && urlActions[0]["url-pattern"];
-          if(link) {
-            //Expand the link and modify the URL on the fly to match the expanded link
-            var linkId = kind+"_"+metadata.name+"link";
-            itemObj.name=<a id={linkId} href="#" onClick={performUrlAction.bind(this, link, urlActions[0]["open-window"], kind, metadata.name, metadata.namespace, undefined, true)}>
+          var actionMap = item['action-map']
+          if (resourceType == 'application') {  //known link to our detail panel and our custom resource types
+            itemObj.name = <a href="#" onClick={() => resourceType == 'application' ? displayApp(metadata.name, metadata.namespace) : displayDetail(appname, resourceType, metadata.name, metadata.namespace)}>
               {metadata.name}
-            </a>;
-            performUrlAction(link, urlActions[0]["open-window"], kind, metadata.name, metadata.namespace, linkId, false);  //update the link in place
+            </a>
+            itemObj.menuAction = getOverflowMenu(component, actionMap, applicationResourceData, appname, namespace)
           } else {
-              itemObj.name = metadata.name;
+            var urlActions = actionMap && actionMap['url-actions']
+            urlActions = urlActions && urlActions.filter((action) => {
+              return action['name']=='detail'
+            })
+
+            itemObj.menuAction = getOverflowMenu(component, actionMap, undefined, appname, namespace)  //custom actions
+
+            var link = urlActions && urlActions[0] && urlActions[0]['url-pattern']
+            if(link) {
+            //Expand the link and modify the URL on the fly to match the expanded link
+              var linkId = kind+'_'+metadata.name+'link'
+              itemObj.name=<a id={linkId} href="#" onClick={performUrlAction.bind(this, link, urlActions[0]['open-window'], kind, metadata.name, metadata.namespace, undefined, true)}>
+                {metadata.name}
+              </a>
+              performUrlAction(link, urlActions[0]['open-window'], kind, metadata.name, metadata.namespace, linkId, false)  //update the link in place
+            } else {
+              itemObj.name = metadata.name
+            }
           }
-        }
-        rowArray.push(itemObj);
-      });
-      return rowArray
-    }
-  });
+          rowArray.push(itemObj)
+        })
+        return rowArray
+      }
+    })
 } // end of refreshApplicationComponents(...)
 
 // display nested application
 function displayApp(appname, namespace) {
-  let url= location.protocol+'//'+location.host+ CONTEXT_PATH + '/applications/'+encodeURIComponent(appname)+'?namespace='+namespace
-  window.location.href = url;
+  const url= location.protocol+'//'+location.host+ CONTEXT_PATH + '/applications/'+encodeURIComponent(appname)+'?namespace='+namespace
+  window.location.href = url
 }
 
 // display details
 function displayDetail(appname, resourceType, name, namespace) {
   //applications and components are now in the same namespace
-  let url= location.protocol+'//'+location.host+ CONTEXT_PATH + '/applications/'+encodeURIComponent(appname)+'/'+resourceType+'/'+encodeURIComponent(name)+'?namespace='+encodeURIComponent(namespace)+'&parentnamespace='+encodeURIComponent(namespace)
-  window.location.href = url;
+  const url= location.protocol+'//'+location.host+ CONTEXT_PATH + '/applications/'+encodeURIComponent(appname)+'/'+resourceType+'/'+encodeURIComponent(name)+'?namespace='+encodeURIComponent(namespace)+'&parentnamespace='+encodeURIComponent(namespace)
+  window.location.href = url
 }

--- a/src-web/definitions/index.js
+++ b/src-web/definitions/index.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src-web/definitions/job.js
+++ b/src-web/definitions/job.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src-web/index.js
+++ b/src-web/index.js
@@ -18,95 +18,14 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { Switch, Route, BrowserRouter as Router } from 'react-router-dom'
-import msgs from '../nls/kappnav.properties'
 import ViewContainer from './components/ViewContainer.jsx'
-import { CONTEXT_PATH , RESOURCE_TYPES} from './actions/constants'
+import { Provider } from 'react-redux'
+import store from './store'
 
-var paths = location.pathname.split('/')
-paths = paths.filter(function(e){return e})
 
-if(paths.length==1 || (paths.length==2 && paths[1] == 'applications') ) { //Application View
+ReactDOM.render(
+  <Provider store={store}>
+    <ViewContainer />
+  </Provider>,
+  document.getElementById('app'));
 
-  ReactDOM.render(
-    <Router>
-      <div>
-        <Route exact render={(props) => <ViewContainer {...props} view='AppView' viewTitle={msgs.get('page.applicationView.title')}
-            location={location}
-        />} />
-      </div>
-    </Router>,
-    document.getElementById('app')
-  );
-
-} else if(paths.length === 3 && (paths[1] === 'applications') ) { // Component View
-
-  let title = msgs.get('page.applicationView.title') // default = application
-  let titleUrl = CONTEXT_PATH + '/applications' // default = application
-  let resourceType = RESOURCE_TYPES.APPLICATION
-
-  let resourceName = decodeURIComponent(paths[2])
-  let url = new URL(location.href)
-  let ns = decodeURIComponent(url.searchParams.get("namespace"))
-  ReactDOM.render(
-    <Router>
-      <div>
-        <Route exact path={location.pathname}
-                    render={(props) => <ViewContainer {...props}
-                                         view = 'ComponentView'
-                                         viewTitle = {resourceName}
-                                         name = {resourceName}
-                                         resourceType = {resourceType}
-                                         namespace = {ns}
-                                         breadcrumbItems = {[
-                                                             {label : title, url : titleUrl},
-                                                             {label : resourceName}  
-                                                            ]} 
-                                        />
-                            }
-        />
-      </div>
-    </Router>,
-    document.getElementById('app')
-  );
-
-} else if(paths.length === 5 && (paths[1] === 'applications') ) { //Detail View
-
-  let name = decodeURIComponent(paths[2])
-  let resourceType = paths[3]
-  let itemName = decodeURIComponent(paths[4])
-  let url = new URL(location.href);
-  let ns = decodeURIComponent(url.searchParams.get("namespace"))
-  let parent_ns = decodeURIComponent(url.searchParams.get("parentnamespace"))
-  let title = msgs.get('page.applicationView.title')
-  
-  ReactDOM.render(
-    <Router>
-      <div>
-        <Route exact path={location.pathname}
-                    render={(props) => <ViewContainer {...props}
-                                         view='DetailView'
-                                         viewTitle={itemName}
-                                         name= {itemName}
-                                         namespace = {ns}
-                                         resourceType = {resourceType}
-                                         breadcrumbItems={[{label:title, url:CONTEXT_PATH+'/' + paths[1]},
-                                                           {label:name, url:CONTEXT_PATH+'/'+paths[1]+'/'+encodeURIComponent(name)+'?namespace='+encodeURIComponent(parent_ns)},
-                                                           {label:itemName, url:CONTEXT_PATH+'/'+paths[1]+'/'+encodeURIComponent(name)+'/'+resourceType+'/'+encodeURIComponent(itemName)+'?namespace='+encodeURIComponent(ns)+'&parentnamespace='+encodeURIComponent(parent_ns)} ]} />} />
-      </div>
-    </Router>,
-    document.getElementById('app')
-  );
-
-} else if(paths.length === 2 && paths[1] === 'jobs')  { // Command action jobs view
-
-  ReactDOM.render(
-    <Router>
-      <div>
-        <Route exact render={(props) => 
-          <ViewContainer {...props} view='JobView' viewTitle={msgs.get('page.jobsView.title')} location={location}/>}/>
-      </div>
-    </Router>,
-    document.getElementById('app')
-  );
-}

--- a/src-web/index.js
+++ b/src-web/index.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,5 +27,5 @@ ReactDOM.render(
   <Provider store={store}>
     <ViewContainer />
   </Provider>,
-  document.getElementById('app'));
+  document.getElementById('app'))
 

--- a/src-web/lib/BaseService.js
+++ b/src-web/lib/BaseService.js
@@ -1,0 +1,42 @@
+export const fetchNamespaces = () => {
+    return fetch('/kappnav/namespaces')
+        .then(res => res.json())
+        .then(result => {
+            var namespacesArray = []
+            result.namespaces.forEach((ns) => {
+                var itemObj = {}
+                itemObj.Name = ns.metadata.name
+                namespacesArray.push(itemObj)
+            });
+            return namespacesArray
+        });
+}
+
+
+export const fetchExistingSecrets = () => {
+    return fetch('/kappnav/secrets/credential-type/app-navigator')
+        .then(res => res.json())
+        .then(result => {
+            var existingSecretsArray = []
+            result.secrets.forEach((ns) => {
+                var itemObj = {}
+                itemObj.Name = ns.metadata.name
+                existingSecretsArray.push(itemObj)
+            });
+            console.log("I am here too" + JSON.stringify(existingSecretsArray, null,4 ))
+            return existingSecretsArray
+        });
+}
+
+export const fetchAppNavConfigMap = () => {
+    return fetch('/kappnav/configmap/kappnav-config?namespace=' + document.documentElement.getAttribute('appnavConfigmapNamespace'))
+        .then(res => res.json())
+        .then(result => {
+            var data = result.data
+            var appNavConfigData = {}
+            appNavConfigData.statuColorMapping = JSON.parse(data['status-color-mapping'])
+            appNavConfigData.statusPrecedence = JSON.parse(data['app-status-precedence'])
+            appNavConfigData.statusUnknown = data['status-unknown']
+            return appNavConfigData
+        });
+}

--- a/src-web/lib/BaseService.js
+++ b/src-web/lib/BaseService.js
@@ -1,42 +1,41 @@
 export const fetchNamespaces = () => {
-    return fetch('/kappnav/namespaces')
-        .then(res => res.json())
-        .then(result => {
-            var namespacesArray = []
-            result.namespaces.forEach((ns) => {
-                var itemObj = {}
-                itemObj.Name = ns.metadata.name
-                namespacesArray.push(itemObj)
-            });
-            return namespacesArray
-        });
+  return fetch('/kappnav/namespaces')
+    .then(res => res.json())
+    .then(result => {
+      var namespacesArray = []
+      result.namespaces.forEach((ns) => {
+        var itemObj = {}
+        itemObj.Name = ns.metadata.name
+        namespacesArray.push(itemObj)
+      })
+      return namespacesArray
+    })
 }
 
 
 export const fetchExistingSecrets = () => {
-    return fetch('/kappnav/secrets/credential-type/app-navigator')
-        .then(res => res.json())
-        .then(result => {
-            var existingSecretsArray = []
-            result.secrets.forEach((ns) => {
-                var itemObj = {}
-                itemObj.Name = ns.metadata.name
-                existingSecretsArray.push(itemObj)
-            });
-            console.log("I am here too" + JSON.stringify(existingSecretsArray, null,4 ))
-            return existingSecretsArray
-        });
+  return fetch('/kappnav/secrets/credential-type/app-navigator')
+    .then(res => res.json())
+    .then(result => {
+      var existingSecretsArray = []
+      result.secrets.forEach((ns) => {
+        var itemObj = {}
+        itemObj.Name = ns.metadata.name
+        existingSecretsArray.push(itemObj)
+      })
+      return existingSecretsArray
+    })
 }
 
 export const fetchAppNavConfigMap = () => {
-    return fetch('/kappnav/configmap/kappnav-config?namespace=' + document.documentElement.getAttribute('appnavConfigmapNamespace'))
-        .then(res => res.json())
-        .then(result => {
-            var data = result.data
-            var appNavConfigData = {}
-            appNavConfigData.statuColorMapping = JSON.parse(data['status-color-mapping'])
-            appNavConfigData.statusPrecedence = JSON.parse(data['app-status-precedence'])
-            appNavConfigData.statusUnknown = data['status-unknown']
-            return appNavConfigData
-        });
+  return fetch('/kappnav/configmap/kappnav-config?namespace=' + document.documentElement.getAttribute('appnavConfigmapNamespace'))
+    .then(res => res.json())
+    .then(result => {
+      var data = result.data
+      var appNavConfigData = {}
+      appNavConfigData.statuColorMapping = JSON.parse(data['status-color-mapping'])
+      appNavConfigData.statusPrecedence = JSON.parse(data['app-status-precedence'])
+      appNavConfigData.statusUnknown = data['status-unknown']
+      return appNavConfigData
+    })
 }

--- a/src-web/reducers/BaseServiceReducer.js
+++ b/src-web/reducers/BaseServiceReducer.js
@@ -1,97 +1,97 @@
-import { fetchNamespaces, fetchExistingSecrets, fetchAppNavConfigMap } from "../lib/BaseService";
+import { fetchNamespaces, fetchExistingSecrets, fetchAppNavConfigMap } from '../lib/BaseService'
 
 const initState = {
-    namespaces: [],
-    secrets: [],
-    appNavConfigMap: {},
-    selectedNamespace: (decodeURIComponent(new URL(location.href).searchParams.get("namespace")) === "null") ? '' : decodeURIComponent(new URL(location.href).searchParams.get("namespace"))
+  namespaces: [],
+  secrets: [],
+  appNavConfigMap: {},
+  selectedNamespace: (decodeURIComponent(new URL(location.href).searchParams.get('namespace')) === 'null') ? '' : decodeURIComponent(new URL(location.href).searchParams.get('namespace'))
 }
 
-const BASESERVICE_LOADING_NAMESPACES = 'BASESERVICE_LOADING_NAMESPACES';
-const BASESERVICE_LOADING_SECRETS = 'BASESERVICE_LOADING_SECRETS';
-const BASESERVICE_LOADING_APPNAVCONFIGMAP = 'BASESERVICE_LOADING_APPNAVCONFIGMAP';
-const BASESERVICE_LOADING_SELECTEDNAMESPACES = 'BASESERVICE_LOADING_SELECTEDNAMESPACES';
+const BASESERVICE_LOADING_NAMESPACES = 'BASESERVICE_LOADING_NAMESPACES'
+const BASESERVICE_LOADING_SECRETS = 'BASESERVICE_LOADING_SECRETS'
+const BASESERVICE_LOADING_APPNAVCONFIGMAP = 'BASESERVICE_LOADING_APPNAVCONFIGMAP'
+const BASESERVICE_LOADING_SELECTEDNAMESPACES = 'BASESERVICE_LOADING_SELECTEDNAMESPACES'
 
 export const loadingNamespaces = (namespaces) => ({
-    type: BASESERVICE_LOADING_NAMESPACES,
-    payload: namespaces
-});
+  type: BASESERVICE_LOADING_NAMESPACES,
+  payload: namespaces
+})
 
 export const loadingSecrets = (secrets) => ({
-    type: BASESERVICE_LOADING_SECRETS,
-    payload: secrets
-});
+  type: BASESERVICE_LOADING_SECRETS,
+  payload: secrets
+})
 
 export const loadingAppNavConfigMap = (appNavConfigMaps) => ({
-    type: BASESERVICE_LOADING_APPNAVCONFIGMAP,
-    payload: appNavConfigMaps
-});
+  type: BASESERVICE_LOADING_APPNAVCONFIGMAP,
+  payload: appNavConfigMaps
+})
 
 export const loadingSelectedNamespace = (selectedNamespace) => ({
-    type: BASESERVICE_LOADING_SELECTEDNAMESPACES,
-    payload: selectedNamespace
-});
+  type: BASESERVICE_LOADING_SELECTEDNAMESPACES,
+  payload: selectedNamespace
+})
 
 export const fetchLoadingNamespaces = () => {
-    return (dispatch) => {
-        fetchNamespaces()
-            .then(namespaces => {
-                dispatch(loadingNamespaces(namespaces));
-            })
-    }
+  return (dispatch) => {
+    fetchNamespaces()
+      .then(namespaces => {
+        dispatch(loadingNamespaces(namespaces))
+      })
+  }
 }
 
 export const fetchLoadingSecrets = () => {
-    return (dispatch) => {
-        fetchExistingSecrets()
-            .then(secrets => {
-                dispatch(loadingSecrets(secrets));
-            })
-    }
+  return (dispatch) => {
+    fetchExistingSecrets()
+      .then(secrets => {
+        dispatch(loadingSecrets(secrets))
+      })
+  }
 }
 
 export const fetchLoadingAppNavConfigMaps = () => {
-    return (dispatch) => {
-        fetchAppNavConfigMap()
-            .then(appNavConfigMaps => {
-                dispatch(loadingAppNavConfigMap(appNavConfigMaps));
-            })
-    }
+  return (dispatch) => {
+    fetchAppNavConfigMap()
+      .then(appNavConfigMaps => {
+        dispatch(loadingAppNavConfigMap(appNavConfigMaps))
+      })
+  }
 }
 
 export const fetchLoadingSelectedNamespace = (selectedNamespace) => {
-    return (dispatch) => {
-        dispatch(loadingSelectedNamespace(selectedNamespace));
-    }
+  return (dispatch) => {
+    dispatch(loadingSelectedNamespace(selectedNamespace))
+  }
 }
 
 
 export default (state = initState, action) => {
-    switch (action.type) {
-        case BASESERVICE_LOADING_NAMESPACES:
-            return {
-                ...state,
-                namespaces: action.payload
-            };
-
-        case BASESERVICE_LOADING_SECRETS:
-            return {
-                ...state,
-                secrets: action.payload
-            };
-
-        case BASESERVICE_LOADING_APPNAVCONFIGMAP:
-            return {
-                ...state,
-                appNavConfigMap: action.payload
-            };
-        
-        case BASESERVICE_LOADING_SELECTEDNAMESPACES:
-            return {
-                ...state,
-                selectedNamespace: action.payload
-            };
-        default:
-            return state;
+  switch (action.type) {
+  case BASESERVICE_LOADING_NAMESPACES:
+    return {
+      ...state,
+      namespaces: action.payload
     }
+
+  case BASESERVICE_LOADING_SECRETS:
+    return {
+      ...state,
+      secrets: action.payload
+    }
+
+  case BASESERVICE_LOADING_APPNAVCONFIGMAP:
+    return {
+      ...state,
+      appNavConfigMap: action.payload
+    }
+
+  case BASESERVICE_LOADING_SELECTEDNAMESPACES:
+    return {
+      ...state,
+      selectedNamespace: action.payload
+    }
+  default:
+    return state
+  }
 }

--- a/src-web/reducers/BaseServiceReducer.js
+++ b/src-web/reducers/BaseServiceReducer.js
@@ -1,0 +1,97 @@
+import { fetchNamespaces, fetchExistingSecrets, fetchAppNavConfigMap } from "../lib/BaseService";
+
+const initState = {
+    namespaces: [],
+    secrets: [],
+    appNavConfigMap: {},
+    selectedNamespace: (decodeURIComponent(new URL(location.href).searchParams.get("namespace")) === "null") ? '' : decodeURIComponent(new URL(location.href).searchParams.get("namespace"))
+}
+
+const BASESERVICE_LOADING_NAMESPACES = 'BASESERVICE_LOADING_NAMESPACES';
+const BASESERVICE_LOADING_SECRETS = 'BASESERVICE_LOADING_SECRETS';
+const BASESERVICE_LOADING_APPNAVCONFIGMAP = 'BASESERVICE_LOADING_APPNAVCONFIGMAP';
+const BASESERVICE_LOADING_SELECTEDNAMESPACES = 'BASESERVICE_LOADING_SELECTEDNAMESPACES';
+
+export const loadingNamespaces = (namespaces) => ({
+    type: BASESERVICE_LOADING_NAMESPACES,
+    payload: namespaces
+});
+
+export const loadingSecrets = (secrets) => ({
+    type: BASESERVICE_LOADING_SECRETS,
+    payload: secrets
+});
+
+export const loadingAppNavConfigMap = (appNavConfigMaps) => ({
+    type: BASESERVICE_LOADING_APPNAVCONFIGMAP,
+    payload: appNavConfigMaps
+});
+
+export const loadingSelectedNamespace = (selectedNamespace) => ({
+    type: BASESERVICE_LOADING_SELECTEDNAMESPACES,
+    payload: selectedNamespace
+});
+
+export const fetchLoadingNamespaces = () => {
+    return (dispatch) => {
+        fetchNamespaces()
+            .then(namespaces => {
+                dispatch(loadingNamespaces(namespaces));
+            })
+    }
+}
+
+export const fetchLoadingSecrets = () => {
+    return (dispatch) => {
+        fetchExistingSecrets()
+            .then(secrets => {
+                dispatch(loadingSecrets(secrets));
+            })
+    }
+}
+
+export const fetchLoadingAppNavConfigMaps = () => {
+    return (dispatch) => {
+        fetchAppNavConfigMap()
+            .then(appNavConfigMaps => {
+                dispatch(loadingAppNavConfigMap(appNavConfigMaps));
+            })
+    }
+}
+
+export const fetchLoadingSelectedNamespace = (selectedNamespace) => {
+    return (dispatch) => {
+        dispatch(loadingSelectedNamespace(selectedNamespace));
+    }
+}
+
+
+export default (state = initState, action) => {
+    switch (action.type) {
+        case BASESERVICE_LOADING_NAMESPACES:
+            return {
+                ...state,
+                namespaces: action.payload
+            };
+
+        case BASESERVICE_LOADING_SECRETS:
+            return {
+                ...state,
+                secrets: action.payload
+            };
+
+        case BASESERVICE_LOADING_APPNAVCONFIGMAP:
+            return {
+                ...state,
+                appNavConfigMap: action.payload
+            };
+        
+        case BASESERVICE_LOADING_SELECTEDNAMESPACES:
+            return {
+                ...state,
+                selectedNamespace: action.payload
+            };
+        default:
+            return state;
+    }
+}

--- a/src-web/store.js
+++ b/src-web/store.js
@@ -1,0 +1,14 @@
+import { createStore, applyMiddleware, combineReducers } from 'redux';
+import thunk from 'redux-thunk';
+import { composeWithDevTools } from 'redux-devtools-extension';
+import BaseReducer from './reducers/BaseServiceReducer';
+
+const reducer = combineReducers({
+  baseInfo: BaseReducer,
+})
+
+export default createStore(reducer,
+  composeWithDevTools(
+    applyMiddleware(thunk)
+  )
+);

--- a/src-web/store.js
+++ b/src-web/store.js
@@ -1,7 +1,7 @@
-import { createStore, applyMiddleware, combineReducers } from 'redux';
-import thunk from 'redux-thunk';
-import { composeWithDevTools } from 'redux-devtools-extension';
-import BaseReducer from './reducers/BaseServiceReducer';
+import { createStore, applyMiddleware, combineReducers } from 'redux'
+import thunk from 'redux-thunk'
+import { composeWithDevTools } from 'redux-devtools-extension'
+import BaseReducer from './reducers/BaseServiceReducer'
 
 const reducer = combineReducers({
   baseInfo: BaseReducer,
@@ -11,4 +11,4 @@ export default createStore(reducer,
   composeWithDevTools(
     applyMiddleware(thunk)
   )
-);
+)

--- a/src-web/util/accessibility.js
+++ b/src-web/util/accessibility.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src-web/util/keyboard/index.js
+++ b/src-web/util/keyboard/index.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src-web/util/keyboard/left-nav.js
+++ b/src-web/util/keyboard/left-nav.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src-web/util/keyboard/nav-modal.js
+++ b/src-web/util/keyboard/nav-modal.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,8 @@ module.exports = {
         enforce: 'pre',
         loader: 'eslint-loader',
         options: {
-          quiet: true
+          presets: ['env', 'react', 'es2015'],
+          plugins: ['transform-class-properties']
         }
       },
       {

--- a/webpack.dll.js
+++ b/webpack.dll.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,22 +31,22 @@ process.env.BABEL_ENV = 'client'
 module.exports = {
   entry: {
     'vendorappnav': [
-	  'babel-polyfill',
+      'babel-polyfill',
       'carbon-components-react',
       'loadable-components',
       'lodash',
       'moment',
-	  'node-libs-browser',
+      'node-libs-browser',
       'normalizr',
       'prop-types',
-	  "react-ace",
+      'react-ace',
       'react-dom',
       'react-dom/server',
       'react-router-dom',
       'react',
       'redux-logger',
       'redux-thunk',
-	  'react-transition-group',
+      'react-transition-group',
       'reselect'
     ]
   },


### PR DESCRIPTION
Eslint was enabled in the `kappnav/ui` directory and changes were made to get rid of the linter errors. The majority of the issues were related to:
- Incorrect indenting 
- Trailing spaces 
- Extra semicolons 
- Proptypes missing validation **
- Array index used in key **
- Referencing the previous state in the setState method **
- Declared variables that weren't being used ** 

The issues with (**) next to them were not fixed in all the files, since they require better understanding of the code or more refactoring. Those errors were "suppressed" by using eslint-disable in the comments. I've opened https://github.com/kappnav/Issues/issues/36 so these issues get addressed in the future. 