### PR TITLE
refactor: Move inline code to files

### DIFF
--- a/app.js
+++ b/app.js
@@ -137,22 +137,11 @@ app.use('/kappnav-ui/openshift/appNavIcon.css', (req, res) => {
     if (!error && response.statusCode === 200) {
       var json = JSON.parse(body)
       var url = json.data['kappnav-url']
-      const appNavIcon =
-          `
-            .icon-appnav {
-              background-repeat: no-repeat;
-              background-image: url(${url}/graphics/KAppNavlogo.svg);
-              height: 20px;
-            }
- 
-           .icon-kappnav-feature {
-              display: block;
-              background-repeat: no-repeat;
-              background-image: url(${url}/graphics/KAppNavlogo.svg);
-              height: 72px;
-              width: 72px;
-            }
-          `
+
+      let fileContent = fs.readFileSync('./openshift/appNavIcon.css', 'utf8')
+      // Replace all `${url}` strings
+      const appNavIcon = fileContent.replace(/\$\{url\}/g, url)
+
       res.type('.css')
       res.send(appNavIcon)
     } else {
@@ -171,17 +160,11 @@ app.use('/kappnav-ui/openshift/featuredApp.js', (req, res) => {
     if (!error && response.statusCode === 200) {
       var json = JSON.parse(body)
       var url = json.data['kappnav-url']
-      const featuredApp =
-          `
-            (function() {
-              window.OPENSHIFT_CONSTANTS.SAAS_OFFERINGS = [{
-                  title: "kAppNav",                           // The text label
-                  icon: "icon-kappnav-feature",               // The icon you want to appear
-                  url: "${url}",      //  Where to go when this item is clicked
-                  description: "Kubernetes Application Navigator"      // Short description
-                }]
-            }())
-          `
+
+      let fileContent = fs.readFileSync('./openshift/featuredApp.js', 'utf8')
+      // Replace all `${url}` strings
+      const featuredApp = fileContent.replace(/\$\{url\}/g, url)
+
       res.type('.js')
       res.send(featuredApp)
     } else {
@@ -200,17 +183,11 @@ app.use('/kappnav-ui/openshift/appLauncher.js', (req, res) => {
     if (!error && response.statusCode === 200) {
       var json = JSON.parse(body)
       var url = json.data['kappnav-url']
-      const appLauncher =
-          `
-          (function() {
-            window.OPENSHIFT_CONSTANTS.APP_LAUNCHER_NAVIGATION = [{
-              title: "kAppNav",                            // The text label
-              iconClass: "icon-appnav",                    // The icon you want to appearl
-              href: "${url}",        // Where to go when this item is clicked
-              tooltip: "Kubernetes Application Navigator"             // Optional tooltip to display on hover
-            }]
-          }())
-          `
+
+      let fileContent = fs.readFileSync('./openshift/appLauncher.js', 'utf8')
+      // Replace all `${url}` strings
+      const appLauncher = fileContent.replace(/\$\{url\}/g, url)
+
       res.type('.js')
       res.send(appLauncher)
     } else {

--- a/openshift/appLauncher.js
+++ b/openshift/appLauncher.js
@@ -1,3 +1,20 @@
+/*****************************************************************
+ *
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *****************************************************************/
 (function() {
     window.OPENSHIFT_CONSTANTS.APP_LAUNCHER_NAVIGATION = [{
         title: "kAppNav",                            // The text label

--- a/openshift/appLauncher.js
+++ b/openshift/appLauncher.js
@@ -1,0 +1,8 @@
+(function() {
+    window.OPENSHIFT_CONSTANTS.APP_LAUNCHER_NAVIGATION = [{
+        title: "kAppNav",                            // The text label
+        iconClass: "icon-appnav",                    // The icon you want to appearl
+        href: "${url}",                              // Where to go when this item is clicked
+        tooltip: "Kubernetes Application Navigator"  // Optional tooltip to display on hover
+    }]
+}())

--- a/openshift/appNavIcon.css
+++ b/openshift/appNavIcon.css
@@ -1,0 +1,13 @@
+.icon-appnav {
+    background-repeat: no-repeat;
+    background-image: url(${url}/graphics/KAppNavlogo.svg);
+    height: 20px;
+}
+
+.icon-kappnav-feature {
+    display: block;
+    background-repeat: no-repeat;
+    background-image: url(${url}/graphics/KAppNavlogo.svg);
+    height: 72px;
+    width: 72px;
+}

--- a/openshift/appNavIcon.css
+++ b/openshift/appNavIcon.css
@@ -1,3 +1,20 @@
+/*****************************************************************
+ *
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *****************************************************************/
 .icon-appnav {
     background-repeat: no-repeat;
     background-image: url(${url}/graphics/KAppNavlogo.svg);

--- a/openshift/featuredApp.js
+++ b/openshift/featuredApp.js
@@ -1,3 +1,20 @@
+/*****************************************************************
+ *
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *****************************************************************/
 (function() {
     window.OPENSHIFT_CONSTANTS.SAAS_OFFERINGS = [{
         title: "kAppNav",                           // The text label

--- a/openshift/featuredApp.js
+++ b/openshift/featuredApp.js
@@ -1,0 +1,8 @@
+(function() {
+    window.OPENSHIFT_CONSTANTS.SAAS_OFFERINGS = [{
+        title: "kAppNav",                           // The text label
+        icon: "icon-kappnav-feature",               // The icon you want to appear
+        url: "${url}",      //  Where to go when this item is clicked
+        description: "Kubernetes Application Navigator"      // Short description
+    }]
+}())


### PR DESCRIPTION
Fixes kappnav/issues#39

- Move the javascript and stylesheet code from being inline in the code,
to dedicated files.  Use node's filesystem read to get the code from the
new files.