### PR TITLE
i18n: Enable translatable message for error notification close button

### DIFF
--- a/src-web/components/kappnav/modals/NavModal.js
+++ b/src-web/components/kappnav/modals/NavModal.js
@@ -418,7 +418,7 @@ class NavModalForm extends React.PureComponent {
             </ul>
           </div>}
         <div className='modal-inner-content'>
-          {validationErrors.form && <InlineNotification kind='error' title='' subtitle={msgs.get('formerror.missing')} />}
+          {validationErrors.form && <InlineNotification kind='error' title='' iconDescription={msgs.get('modal.button.close')} subtitle={msgs.get('formerror.missing')} />}
           {(postStatus === REQUEST_STATUS.ERROR || parsingError) &&
             <InlineNotification
               kind='error'


### PR DESCRIPTION
# Before fix
This is using some hardcoded string `closes notification` inside Carbon.
![image](https://user-images.githubusercontent.com/31117513/67305580-277bd780-f4bb-11e9-979b-7106829a86df.png)

# After fix
This is using a message in the kappnav/ui code https://github.com/kappnav/ui/blob/415b7ab2fa84a7910ff405577103406661c6602c/nls/kappnav.properties#L112
![image](https://user-images.githubusercontent.com/31117513/67306752-1af87e80-f4bd-11e9-9b73-a9501131a437.png)