### PR TITLE
i18n(dropdown): Use the `*.nls` keys for command actions

### DIFF
--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -439,14 +439,21 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
         })()}
         {(() => {
           if(cmdActions) {
-            return cmdActions.map((action, cmdindex) => (
-              <OverflowMenuItem key={action.name}
+            return cmdActions.map((action, cmdindex) => {
+              let actionLabel = action['text.nls'] ? msgs.get(action['text.nls']) : action.text
+              let actionDesc = action['description.nls'] ? msgs.get(action['description.nls']) : action.description
+              return <OverflowMenuItem key={action.name}
                 primaryFocus={cmdindex === 0 && !hasUrlActions && !hasStaticActions}
-                itemText={action.text ? action.text : action.description ? action.description : action.name}
+                itemText={actionLabel}
                 onClick={openModal.bind(this, "action", cloneData, applicationName, applicationNamespace, action, cmdInputs)}
-                onFocus={(e) => {if(action.description) e.target.title = action.description}}
-                onMouseEnter={(e) => {if(action.description) e.target.title = action.description}} />
-            ))
+                onFocus={(e) => {
+                  if(actionDesc){ e.target.title = actionDesc }
+                }}
+                onMouseEnter={(e) => {
+                  if(actionDesc){ e.target.title = actionDesc }
+                }} 
+              />
+            })
           }
         })()}
       </OverflowMenu>


### PR DESCRIPTION
Fixes kappnav/issues#58
Related to #46 

- The command actions can have optional message keys in the ConfigMap.
Use `text.nls` and `description.nls` keys when they are present in any
`cmd-actions` section in the actions ConfigMaps