### PR TITLE
i18n: Add configurable msg to error close button

### DIFF
--- a/src-web/components/kappnav/modals/NavModal.js
+++ b/src-web/components/kappnav/modals/NavModal.js
@@ -406,7 +406,7 @@ class NavModalForm extends React.PureComponent {
             </ul>
           </div>}
         <div className='modal-inner-content'>
-          {validationErrors.form && <InlineNotification kind='error' title='' subtitle={msgs.get('formerror.missing')} />}
+          {validationErrors.form && <InlineNotification kind='error' title='' iconDescription={msgs.get('modal.button.close')} subtitle={msgs.get('formerror.missing')} />}
           {(postStatus === REQUEST_STATUS.ERROR || parsingError) &&
             <InlineNotification
               kind='error'


### PR DESCRIPTION
Related to #47
- The close button from `<InlineNotification>` is customizable.  Specify
 a customizable message to support non-English messages.