### PR TITLE
i18n(modal): Enable customizable tooltip

### DIFF
--- a/nls/kappnav.properties
+++ b/nls/kappnav.properties
@@ -240,3 +240,11 @@ application = Application
 job = Job
 
 not.assigned = Not Assigned
+
+# Carbon React <NumberInput> - start
+# These message keys are set by <NumberInput>
+
+increment.number=Increment the number
+decrement.number=Decrement the number
+
+# Carbon React <NumberInput> - end

--- a/src-web/components/kappnav/common/ModalFormItems.js
+++ b/src-web/components/kappnav/common/ModalFormItems.js
@@ -24,6 +24,8 @@ import { TextInput, Icon, Select, SelectItem, NumberInput } from 'carbon-compone
 import withMultiple from './ModalListItem'
 import { FieldWrapper } from './FormField'
 
+const translateWithId = (locale, id) => msgs.get(id)
+
 const transform = (field, handleChange, event) => {
   handleChange(field, event.target.value)
 }
@@ -42,7 +44,9 @@ const NumberField = ({ onChange, labelText, content, field, id, value, invalid, 
       invalid={invalid}
       hideLabel
       invalidText={` ${msgs.get('formerror.required', locale)}`}
-      onChange={handleNumberFieldChange.bind(this, field, onChange)} />
+      onChange={handleNumberFieldChange.bind(this, field, onChange)}
+      translateWithId={translateWithId.bind(null, document.documentElement.lang)}
+    />
   </FieldWrapper>
 
 const General = ({ form, onChange, children, error, labelName, labelContent }, context) => {


### PR DESCRIPTION
- Add the `translateWithId` field to the `<NumberInput>` to allow for
customizable tooltip text for the up and down arrows.  To customize the
tooltips, change the messages in `kappnav.properties`.