### PR TITLE
Put back licences

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,7 @@ RUN microdnf update -y \
   && microdnf clean all
 
 RUN mkdir -p /opt/ibm/app-nav-ui/app && chown -R 1001:0 /opt/ibm
+COPY --chown=1001:0 licenses/ /licenses/
 WORKDIR /opt/ibm/app-nav-ui/app
 
 COPY --from=buildapp --chown=1001:0 /app/app.js .


### PR DESCRIPTION
Put back the Dockerfile COPY licenses command that was mistakenly dropped.