### PR TITLE
feat: Show and hide dropdown menu items

### DIFF
--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -377,9 +377,52 @@ export const validateUrl = (url) => {
   return result
 }
 
+/**
+ * Determine if an action is enabled for a resource
+ * @param {*} resourceLabels - a resource's labels
+ * @param {*} action - an action's data
+ */
+function isActionEnabled(resourceLabels, action) {
+  let enablementLabel = action[CONFIG_CONSTANTS.ENABLEMENT_LABEL]
+  if(! enablementLabel) {
+    // If enablement-label is missing, assume the action is enabled for the resource
+    return true
+  }
+
+  const isEnabled = resourceLabels[enablementLabel]
+  if(isEnabled) {
+    // The action's enablement-label has value X and 
+    // the resource has a label of X.  This means the
+    // action is enabled for this particular resource
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Return a list containing only enabled actions for a resource
+ * @param {*} resourceLabels - an object of a resource's labels
+ * @param {*} actions - list of actions for the resource
+ */
+function removeDisabledActions(resourceLabels, actions) {
+  // Loop from end to beginning to ensure each element is processed
+  // even if elements are being removed in the loop
+  for(let index = actions.length - 1; index >= 0; index--) {
+    // Remove any disabled command actions
+    const one_action = actions[index]
+    const isDisabled = ! isActionEnabled(resourceLabels, one_action)
+    if(isDisabled) {
+      actions.splice(index, 1)
+    }
+  }
+  return actions
+}
+
 export const getOverflowMenu = (componentData, actionMap, staticResourceData, applicationName, applicationNamespace) => {
   const cloneData = lodash.cloneDeep(componentData)
   var itemId = cloneData.metadata.uid
+  const resourceLabels = cloneData.metadata.labels
 
   //remove fields that should not show up on an editor
   delete cloneData.metadata.creationTimestamp
@@ -414,6 +457,9 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
         })()}
         {(() => {
           if(urlActions) {
+
+            urlActions = removeDisabledActions(resourceLabels, urlActions)
+
             urlActions.forEach((action) => { //try to cache the links ahead of time
               var kind = componentData && componentData.kind
               var namespace = componentData && componentData.metadata && componentData.metadata.namespace
@@ -439,6 +485,9 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
         })()}
         {(() => {
           if(cmdActions) {
+
+            cmdActions = removeDisabledActions(resourceLabels, cmdActions)
+
             return cmdActions.map((action, cmdindex) => {
               let actionLabel = action['text.nls'] ? msgs.get(action['text.nls']) : action.text
               let actionDesc = action['description.nls'] ? msgs.get(action['description.nls']) : action.description

--- a/src-web/actions/constants.js
+++ b/src-web/actions/constants.js
@@ -49,7 +49,8 @@ export const CONFIG_CONSTANTS = {
   INPUTS: 'inputs',
   MENU_ITEM: 'menu-item',
   REQUIRES_INPUT: 'requires-input',
-  URL_ACTIONS: 'url-actions'
+  URL_ACTIONS: 'url-actions',
+  ENABLEMENT_LABEL: 'enablement-label'
 }
 
 export const STATUS_COLORS = {


### PR DESCRIPTION
- Only show actions that are applicable for each resource based on the
resources's labels.

- Must remove the disabled actions from the actions list so that the `primaryFocus` attribute for `<OverflowMenuItem>` is correctly set on the first enabled action menu item.