### PR TITLE
Remove extra horizontal scroll on windows

### DIFF
--- a/scss/table.scss
+++ b/scss/table.scss
@@ -48,8 +48,14 @@
   tr.bx--expandable-row-v2:hover + tr[data-child-row] > td {
     border-right: 0;
   }
+
 }
 
+tr.bx--expandable-row-v2 + tr[data-child-row] td {
+  padding-right: 0;
+  padding-bottom: 0;
+}
+  
 .bx--overflow-menu-options__option--danger:only-child {
   border-top: 0;
 }
@@ -138,4 +144,8 @@
 
 .widthOfSectionDataKeyAndValue{
   width: 1000px;
+}
+
+.bx--row {
+  width: 100%
 }


### PR DESCRIPTION
An extra horizontal scroll bar is unnecceesarily showing on windows for an open row the datatables.

Before:
![image](https://user-images.githubusercontent.com/29546393/68713316-2d695380-0563-11ea-84d4-34b8658647ca.png)

After my changes:
![image](https://user-images.githubusercontent.com/29546393/68711337-0a3ca500-055f-11ea-887e-694313a02df1.png)
