### PR TITLE
support enablement-annotation

### DIFF
--- a/src-web/actions/constants.js
+++ b/src-web/actions/constants.js
@@ -50,7 +50,8 @@ export const CONFIG_CONSTANTS = {
   MENU_ITEM: 'menu-item',
   REQUIRES_INPUT: 'requires-input',
   URL_ACTIONS: 'url-actions',
-  ENABLEMENT_LABEL: 'enablement-label'
+  ENABLEMENT_LABEL: 'enablement-label',
+  ENABLEMENT_ANNOTATION: 'enablement-annotation'
 }
 
 export const STATUS_COLORS = {


### PR DESCRIPTION
Need to support both enablement-label AND enablement-annotation.

The action is enabled if either is specified.  It's OK to specify both, even though there is no defined use case for that.  If both are specified, the action is enabled either the matching label OR annotation is specified. 
