### PR TITLE
fix: resource type moved from state to props

### DIFF
--- a/src-web/components/kappnav/ComponentView.jsx
+++ b/src-web/components/kappnav/ComponentView.jsx
@@ -226,13 +226,13 @@ class ComponentView extends Component {
 
     var self = this;
     window.setInterval(function(){
-      refreshResource(self.state.name, self.props.baseInfo.selectedNamespace, self.state.resourceType, self.props.baseInfo.appNavConfigMap).then(result => {
+      refreshResource(self.state.name, self.props.baseInfo.selectedNamespace, self.props.resourceType, self.props.baseInfo.appNavConfigMap).then(result => {
         self.setState({loading: false, data: result});
       });
     }, 10000);
 
     window.setInterval(function(){
-      refreshResourceComponent(self.state.name, self.props.baseInfo.selectedNamespace, self.state.resourceType, self.props.baseInfo.appNavConfigMap).then(result => {
+      refreshResourceComponent(self.state.name, self.props.baseInfo.selectedNamespace, self.props.resourceType, self.props.baseInfo.appNavConfigMap).then(result => {
         if(result === null) {
           this.setState({loadingComponents: false});
         }


### PR DESCRIPTION
Fixes kappnav/issues#94

- The ComponentView gets the resourceType from the props instead of the
state.

# Background Info
In #45, we changed the where we get the `resourceType` from `this.state` to `this.props`.  I missed a spot in the code where we are still references the no longer valid `this.state.resourceType`