### PR TITLE
1052 removing dup navigation panel kappnav

### DIFF
--- a/src-web/components/LeftNav.js
+++ b/src-web/components/LeftNav.js
@@ -21,6 +21,7 @@ import React from 'react'
 import msgs from '../../nls/kappnav.properties'
 import PropTypes from 'prop-types'
 import { CSSTransition } from 'react-transition-group'
+import {getExtendedRoutes} from  './extensions/NavigationExtension'
 
 require('../../scss/left-nav.scss')
 
@@ -54,6 +55,12 @@ class LeftNav extends React.Component {
         <li className="left-nav-item primary-nav-item">
         <a role='menuitem' href="/kappnav-ui/jobs" title={msgs.get('page.jobsView.title')}>{msgs.get('page.jobsView.title')}</a>
         </li>
+        {/* getting all extended routes if any */}
+        {getExtendedRoutes().length > 0 ? getExtendedRoutes().map((route) => {
+            return <li className="left-nav-item primary-nav-item">
+              <a role='menuitem' href={route.href} title={route.title}>{route.title}</a>
+            </li>
+        }): null}
       </ul>
     )
   } // end of renderRoutes(...)

--- a/src-web/components/extensions/NavigationExtension.js
+++ b/src-web/components/extensions/NavigationExtension.js
@@ -1,0 +1,25 @@
+/*****************************************************************
+ *
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *****************************************************************/
+
+import msgs from '../../../nls/kappnav.properties'
+
+// function to get all the extended routes
+export const getExtendedRoutes = () => {
+  let extendedRoutes = [];
+	return extendedRoutes
+}


### PR DESCRIPTION
This PR is for the issue https://github.ibm.com/WASCloudPrivate/appnav-roadmap/issues/1052
This is to remove the duplicate code for LeftNav.js file by adding the NavigationExtension.js file to Kappnav.