### PR TITLE
Fixing 'All namespaces' button position

### DIFF
--- a/scss/namespace-dropdown.scss
+++ b/scss/namespace-dropdown.scss
@@ -19,7 +19,7 @@
 @import 'node_modules/carbon-components/scss/globals/scss/_colors';
 
 .namespaces {
-  position: fixed;
+  position: absolute;
   z-index: 6001;
   right: 5%;
   top: 4rem;


### PR DESCRIPTION
Original issue (described in https://github.ibm.com/WASCloudPrivate/appnav-roadmap/issues/815):
![image](https://user-images.githubusercontent.com/6720263/71747713-01b56c00-2e36-11ea-8b52-497183fc8a45.png)
The 'All namespaces' dropdown covers the 'Add Application' button.

After fix:
![image](https://user-images.githubusercontent.com/6720263/71747749-11cd4b80-2e36-11ea-9df1-3b8caa540438.png)
