### PR TITLE
Adding row with message in empty resource table

### DIFF
--- a/nls/kappnav.properties
+++ b/nls/kappnav.properties
@@ -89,10 +89,8 @@ table.header.age = Age
 table.header.console = Console
 
 # Messages for when the resource table is empty 
-table.empty = There are no {0} here. Go add one with 
+table.empty = No {0} have been added yet. 
 table.empty.applications = applications
-table.empty.wasNdCells = WAS ND cells
-table.empty.libertyCollectives = Liberty collectives
 
 svg.description.asc = Sort rows by this header in ascending order
 svg.description.desc = Sort rows by this header in descending order

--- a/nls/kappnav.properties
+++ b/nls/kappnav.properties
@@ -88,6 +88,12 @@ table.header.component = Component
 table.header.age = Age
 table.header.console = Console
 
+# Messages for when the resource table is empty 
+table.empty = There are no {0} here. Go add one with 
+table.empty.applications = applications
+table.empty.wasNdCells = WAS ND cells
+table.empty.libertyCollectives = Liberty collectives
+
 svg.description.asc = Sort rows by this header in ascending order
 svg.description.desc = Sort rows by this header in descending order
 svg.description.overflowMenu = Open and close list of options

--- a/scss/table.scss
+++ b/scss/table.scss
@@ -149,3 +149,9 @@ tr.bx--expandable-row-v2 + tr[data-child-row] td {
 .bx--row {
   width: 100%
 }
+
+.addResourceLink {
+  font-weight: 600;
+  color: #3d70b2;
+  cursor: pointer;
+}

--- a/scss/table.scss
+++ b/scss/table.scss
@@ -150,7 +150,7 @@ tr.bx--expandable-row-v2 + tr[data-child-row] td {
   width: 100%
 }
 
-.addResourceLink {
+.emptyTableResourceLink {
   font-weight: 600;
   color: #3d70b2;
   cursor: pointer;

--- a/src-web/components/kappnav/AppView.jsx
+++ b/src-web/components/kappnav/AppView.jsx
@@ -58,7 +58,9 @@ class AppView extends Component {
         {key: 'description', header: 'Description', type: SEARCH_HEADER_TYPES.NOT_SEARCHABLE},
         {key: 'section_data', header: 'section_data', type: SEARCH_HEADER_TYPES.NOT_SEARCHABLE},
         {key: 'section_map', header: 'section_map', type: SEARCH_HEADER_TYPES.NOT_SEARCHABLE}
-      ]
+      ],
+      viewType: 'table.empty.applications',
+      modalType: 'button.application.create'
     };
 
     // make 'this' visible to class methods
@@ -101,6 +103,8 @@ class AppView extends Component {
           namespace={this.props.baseInfo.selectedNamespace}
           namespaces={this.props.baseInfo.namespaces}
           resourceType={applicationResourceData.resourceType}
+          viewType={this.state.viewType}
+          modalType={this.state.modalType}
           createNewModal={(namespace, namespaces, existingSecrets) => {
             return (
               <DataTable.TableToolbarContent>

--- a/src-web/components/kappnav/common/ResourceTable.js
+++ b/src-web/components/kappnav/common/ResourceTable.js
@@ -456,7 +456,7 @@ class ResourceTable extends React.Component {
 											var msg = msgs.get('table.empty', [resource]);
 
 											return (
-												<TableRow><TableCell colSpan={headers.length + 1}>{msg} <span className='addResourceLink' id='navModalLink'>{modal}</span>.</TableCell></TableRow>
+												<TableRow><TableCell colSpan={headers.length + 1}>{msg} <span className='emptyTableResourceLink' id='navModalLink'>{modal}</span>.</TableCell></TableRow>
 											)
 										} else {
 											return(

--- a/src-web/components/kappnav/common/ResourceTable.js
+++ b/src-web/components/kappnav/common/ResourceTable.js
@@ -113,17 +113,22 @@ class ResourceTable extends React.Component {
 		}
 	}
 
-	/* This function is hidding the expandable icon from the DataTable Carbon Components only for
-	   those resources which doesn't have the "section-map" attribute or if the "section-map" 
-	   attribute is empty*/
-	componentDidMount() {
-		//If the resource table is empty, a row with text should have a link to the 'Add [resoure_name]' navmodal
-		//The "link" should trigger a click on the 'Add [resource_name]' button above the table
+	/* This function is to add the onlcick to the 'Add [resource_name]' link in the message row of an empty resource table.
+	When the resource table is empty, a row with text should have a link to the 'Add [resoure_name]' navmodal.
+	Clicking this link should trigger a click on the 'Add [resource_name]' button above the table */
+	connectAddLinkOnClick() {
 		var addResourceButton = document.getElementById('create-application');
 		var navModalLink = document.getElementById('navModalLink');
 		if (navModalLink && addResourceButton) {
 			navModalLink.onclick = function() {addResourceButton.click()};
 		}
+	}
+
+	/* This function is hidding the expandable icon from the DataTable Carbon Components only for
+	   those resources which doesn't have the "section-map" attribute or if the "section-map" 
+	   attribute is empty*/
+	componentDidMount() {
+		this.connectAddLinkOnClick()
 
 		if (this.props.rows.length !== 0) {
 			for (var i = 0; i < this.props.rows.length; i++) {
@@ -145,13 +150,7 @@ class ResourceTable extends React.Component {
 	   those resources which doesn't have the "section-map" attribute or if the "section-map" 
 	   attribute is empty by first making expandable icon visible on every rows of the DataTable*/
 	componentDidUpdate() {
-		//If the resource table is empty, a row with text should have a link to the 'Add [resoure_name]' navmodal
-		//The "link" should trigger a click on the 'Add [resource_name]' button above the table
-		var addResourceButton = document.getElementById('create-application');
-		var navModalLink = document.getElementById('navModalLink');
-		if (navModalLink && addResourceButton) {
-			navModalLink.onclick = function() {addResourceButton.click()};
-		}
+		this.connectAddLinkOnClick()
 
 		if (this.props.rows.length !== 0) {
 			for (var i = 0; i < this.props.rows.length; i++) {

--- a/src-web/components/kappnav/common/ResourceTable.js
+++ b/src-web/components/kappnav/common/ResourceTable.js
@@ -117,6 +117,14 @@ class ResourceTable extends React.Component {
 	   those resources which doesn't have the "section-map" attribute or if the "section-map" 
 	   attribute is empty*/
 	componentDidMount() {
+		//If the resource table is empty, a row with text should have a link to the 'Add [resoure_name]' navmodal
+		//The "link" should trigger a click on the 'Add [resource_name]' button above the table
+		var addResourceButton = document.getElementById('create-application');
+		var navModalLink = document.getElementById('navModalLink');
+		if (navModalLink && addResourceButton) {
+			navModalLink.onclick = function() {addResourceButton.click()};
+		}
+
 		if (this.props.rows.length !== 0) {
 			for (var i = 0; i < this.props.rows.length; i++) {
 				var row = this.props.rows[i]
@@ -137,6 +145,14 @@ class ResourceTable extends React.Component {
 	   those resources which doesn't have the "section-map" attribute or if the "section-map" 
 	   attribute is empty by first making expandable icon visible on every rows of the DataTable*/
 	componentDidUpdate() {
+		//If the resource table is empty, a row with text should have a link to the 'Add [resoure_name]' navmodal
+		//The "link" should trigger a click on the 'Add [resource_name]' button above the table
+		var addResourceButton = document.getElementById('create-application');
+		var navModalLink = document.getElementById('navModalLink');
+		if (navModalLink && addResourceButton) {
+			navModalLink.onclick = function() {addResourceButton.click()};
+		}
+
 		if (this.props.rows.length !== 0) {
 			for (var i = 0; i < this.props.rows.length; i++) {
 				var row = this.props.rows[i]
@@ -356,7 +372,9 @@ class ResourceTable extends React.Component {
 			namespace,
 			namespaces, //this is a list of namespaces that we use to populate the create new modals
 			existingSecrets,
-			createNewModal
+			createNewModal,
+			viewType,
+			modalType
 		} = this.props
 
 		let c;
@@ -427,25 +445,43 @@ class ResourceTable extends React.Component {
 										</TableRow>
 									</TableHead>
 									<TableBody>
-										{rows.map(row => (
-											<React.Fragment key={row.id}>
-												<TableExpandRow {...getRowProps({ row })} ariaLabel={row.id} expandIconDescription={msgs.get('expand')} onClick={() => { this.toggleExpandCollapse(row.id) }}>
-													{row.cells.map(cell => (
-														this.renderCell(row, cell)
-													))}
-												</TableExpandRow>
-												{row.isExpanded && (
-													<TableExpandedRow>
-														<TableCell className="expandedRow" colSpan={headers.length + 1}>
-															<div> {
-																this.renderCellExpanded(row)
-															}</div>
-														</TableCell>
+									{(() => {
+										//When the resource table is empty, add a new row with a message that encourages users to add a new resource 
+										//viewType is undefined when in the Command Actions view
+										//viewType is the message key for the resource type: applications, WAS ND cells, or Liberty collectives
+										//modal is the message key for the title of the add modal that should pop up (ex: "Add Application")
+										if (rows.length === 0 && viewType) {
+											var resource = msgs.get(viewType);
+											var modal = msgs.get(modalType);
+											var msg = msgs.get('table.empty', [resource]);
 
-													</TableExpandedRow>
-												)}
-											</React.Fragment>
-										))}
+											return (
+												<TableRow><TableCell colSpan={headers.length + 1}>{msg} <span className='addResourceLink' id='navModalLink'>{modal}</span>.</TableCell></TableRow>
+											)
+										} else {
+											return(
+												rows.map(row => (
+												<React.Fragment key={row.id}>
+													<TableExpandRow {...getRowProps({ row })} ariaLabel={row.id} expandIconDescription={msgs.get('expand')} onClick={() => { this.toggleExpandCollapse(row.id) }}>
+														{row.cells.map(cell => (
+															this.renderCell(row, cell)
+														))}
+													</TableExpandRow>
+													{row.isExpanded && (
+														<TableExpandedRow>
+															<TableCell className="expandedRow" colSpan={headers.length + 1}>
+																<div> {
+																	this.renderCellExpanded(row)
+																}</div>
+															</TableCell>
+
+														</TableExpandedRow>
+													)}
+												</React.Fragment>
+												))
+											)
+										}
+									})()}
 									</TableBody>
 								</Table>
 							</TableContainer>


### PR DESCRIPTION
**Design:** https://ibm.invisionapp.com/share/NTNZHJPWD37#/screens/319360373

**Issue:** https://github.ibm.com/WASCloudPrivate/appnav-roadmap/issues/1057
The design shows a message in the table behind the overlay that encourages users to add a resource (applications, WAS ND cells, or Liberty collectives) when they don't have any. 

_Note:_ I'm leaving out the 'Learn more' link until we get the content for it.

New row in the Applications view. 
![image](https://user-images.githubusercontent.com/6720263/72169561-f95cb400-3394-11ea-8039-633a28978c5f.png)

View when 'Add Application' link is clicked:
![image](https://user-images.githubusercontent.com/6720263/72169597-0c6f8400-3395-11ea-946f-ca5e80fce5e0.png)
