### PR TITLE
refactor: Move notification to its own component

### DIFF
--- a/src-web/components/kappnav/common/Notification.js
+++ b/src-web/components/kappnav/common/Notification.js
@@ -1,0 +1,75 @@
+/*****************************************************************
+ *
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *****************************************************************/
+
+ // This component handles displaying and managing notifications
+
+import React from 'react'
+import { ToastNotification, Icon } from 'carbon-components-react'
+import moment from 'moment'
+import msgs from '../../../../nls/kappnav.properties'
+import {CONTEXT_PATH} from '../../../actions/constants'
+
+const notificationTimeout = 5000 // ms, how long before auto hiding the notification
+
+const _caption = 
+    <div>
+        {new moment().format('HH:mm:ss   LL')}
+        <a href={location.protocol + '//' + location.host + CONTEXT_PATH + '/jobs'}>
+            <Icon className="launch-icon"
+                name='launch'
+                description={msgs.get('toaster.action.caption')} 
+            />
+        </a>
+    </div>
+
+export default class Notification extends React.PureComponent {
+
+    constructor(props) {
+        super(props)
+        const result = this.props.result
+        const _subtitle =
+            <div>
+            <h3> {msgs.get('toaster.action.subtitle', [result.metadata.annotations['kappnav-job-action-text'], result.metadata.labels['kappnav-job-component-name']])}</h3>
+            <br />
+            </div>
+        
+        this.state = {
+            subtitle : _subtitle,
+            handleClose: this.props.handleClose
+        }
+    }
+
+    render() {
+        const { subtitle, handleClose } = this.state
+        return ( 
+            <ToastNotification
+                caption={_caption}
+                hideCloseButton={false}
+                iconDescription={msgs.get('modal.button.close.the.modal')}
+                onCloseButtonClick={handleClose}
+                kind="info"
+                notificationType="toast"
+                role="alert"
+                className='toaster-style'
+                subtitle={subtitle}
+                timeout={notificationTimeout}
+                title={msgs.get('toaster.action.success')}
+            />
+        )
+    }
+}

--- a/src-web/components/kappnav/modals/ActionMessageModal.js
+++ b/src-web/components/kappnav/modals/ActionMessageModal.js
@@ -19,11 +19,10 @@
 'use strict'
 
 import React from 'react'
-import { ComposedModal, ModalHeader, ModalBody, ToastNotification, Icon } from 'carbon-components-react'
-import {CONTEXT_PATH} from '../../../actions/constants'
+import { ComposedModal, ModalHeader, ModalBody } from 'carbon-components-react'
 import { withRouter } from 'react-router-dom'
 import msgs from '../../../../nls/kappnav.properties'
-import moment from 'moment';
+import Notification from '../common/Notification'
 
 require('../../../../scss/modal.scss')
 class ActionMessageModal extends React.PureComponent {
@@ -82,34 +81,7 @@ class ActionMessageModal extends React.PureComponent {
       //  Toaster component to a different React class Component.
       if (open) {
         return (
-          <ToastNotification
-            caption={
-              <div>
-                {new moment().format('HH:mm:ss   LL')}
-                <a href={location.protocol + '//' + location.host + CONTEXT_PATH + '/jobs'}>
-                  <Icon
-                    className="launch-icon"
-                    name='launch'
-                    description={msgs.get('toaster.action.caption')} />
-                </a>
-              </div>
-            }
-            hideCloseButton={false}
-            iconDescription={msgs.get('modal.button.close.the.modal')}
-            onCloseButtonClick={handleClose}
-            kind="info"
-            notificationType="toast"
-            role="alert"
-            className='toaster-style'
-            subtitle={
-              <div>
-                <h3> {msgs.get('toaster.action.subtitle', [result.metadata.annotations['kappnav-job-action-text'], result.metadata.labels['kappnav-job-component-name']])}</h3>
-                <br />
-              </div>
-            }
-            timeout={5000}
-            title={msgs.get('toaster.action.success')}
-          />
+          <Notification result={result} handleClose={handleClose}/>
         )
       }
       else {


### PR DESCRIPTION
For kappnav/issues#81

- Create a simple wrapper around `<ToasterNotification>`.  Currently,
the usage of the ToasterNotification is the same across our code base.
 With this refactoring, it is easier for any React Component to create a
notification with consistency.