### PR TITLE
Notifications for completed jobs

### DIFF
--- a/nls/kappnav.properties
+++ b/nls/kappnav.properties
@@ -271,7 +271,10 @@ formfield.header.name.placeholder = enter name
 
 toaster.action.success = Action Initiated
 toaster.action.subtitle = {0} has been started for {1}
-toaster.action.caption = View Command Action
+toaster.action.icon.label = View Command Action
+
+toaster.action.completed.title = Action Completed
+toaster.action.completed.subtitle = {0} has been completed for {1}
 
 # Carbon React <NumberInput> - start
 # These message keys are set by <NumberInput>

--- a/src-web/components/ViewContainer.jsx
+++ b/src-web/components/ViewContainer.jsx
@@ -26,6 +26,7 @@ import ComponentView from './kappnav/ComponentView.jsx';
 import JobView from './kappnav/JobView.jsx';
 import { RESOURCE_TYPES } from '../actions/constants';
 import {getExtendedRoutes} from './extensions/RouteExtensions'
+import NotificationHandler from './kappnav/common/NotificationHandler'
 
 class ViewContainer extends Component {
 
@@ -49,10 +50,11 @@ class ViewContainer extends Component {
         }
         else{
         return (
-            <div >
-                <main >
+            <div>
+                <NotificationHandler />
+                <main>
                     <Router>
-                        <Switch >
+                        <Switch>
                             <Route exact path="/kappnav-ui/" component={AppView} />
 
                             <Route exact path="/kappnav-ui/applications" component={AppView} />

--- a/src-web/components/kappnav/common/Notification.js
+++ b/src-web/components/kappnav/common/Notification.js
@@ -32,7 +32,7 @@ const _caption =
         <a href={location.protocol + '//' + location.host + CONTEXT_PATH + '/jobs'}>
             <Icon className="launch-icon"
                 name='launch'
-                description={msgs.get('toaster.action.caption')} 
+                description={msgs.get('toaster.action.icon.label')} 
             />
         </a>
     </div>

--- a/src-web/components/kappnav/common/Notification.js
+++ b/src-web/components/kappnav/common/Notification.js
@@ -43,28 +43,29 @@ export default class Notification extends React.PureComponent {
         super(props)
         const { type, result } = this.props
 
-        let _title = this._determineTitleBasedOnType(type)
+        const { title, subtitleMsgKey } = this._determineTitleAndSubtitleBasedOnType(type)
         
-        const _subtitle =
+        const subtitle =
             <div>
-            <h3> {msgs.get('toaster.action.subtitle', [result.metadata.annotations['kappnav-job-action-text'], result.metadata.labels['kappnav-job-component-name']])}</h3>
+            <h3> {msgs.get(subtitleMsgKey, [result.metadata.annotations['kappnav-job-action-text'], result.metadata.labels['kappnav-job-component-name']])}</h3>
             <br />
             </div>
 
         this.state = {
-            title: _title,
-            subtitle : _subtitle,
+            title: title,
+            subtitle : subtitle,
             handleClose: this.props.handleClose
         }
     }
 
-    _determineTitleBasedOnType(notification_type) {
+    _determineTitleAndSubtitleBasedOnType(notification_type) {
         if(notification_type === 'initiated') {
-            return msgs.get('toaster.action.success')
+            return {title: msgs.get('toaster.action.success'), subtitleMsgKey: 'toaster.action.subtitle'}
         } else if(notification_type === 'completed') {
-            return msgs.get('toaster.action.completed.title')
+            return {title: msgs.get('toaster.action.completed.title'), subtitleMsgKey: 'toaster.action.completed.subtitle'}
         } else {
-            return ''
+            // Fail fast if type is not provided
+            return undefined
         }
     }
 

--- a/src-web/components/kappnav/common/Notification.js
+++ b/src-web/components/kappnav/common/Notification.js
@@ -41,21 +41,35 @@ export default class Notification extends React.PureComponent {
 
     constructor(props) {
         super(props)
-        const result = this.props.result
+        const { type, result } = this.props
+
+        let _title = this._determineTitleBasedOnType(type)
+        
         const _subtitle =
             <div>
             <h3> {msgs.get('toaster.action.subtitle', [result.metadata.annotations['kappnav-job-action-text'], result.metadata.labels['kappnav-job-component-name']])}</h3>
             <br />
             </div>
-        
+
         this.state = {
+            title: _title,
             subtitle : _subtitle,
             handleClose: this.props.handleClose
         }
     }
 
+    _determineTitleBasedOnType(notification_type) {
+        if(notification_type === 'initiated') {
+            return msgs.get('toaster.action.success')
+        } else if(notification_type === 'completed') {
+            return msgs.get('toaster.action.completed.title')
+        } else {
+            return ''
+        }
+    }
+
     render() {
-        const { subtitle, handleClose } = this.state
+        const { title, subtitle, handleClose } = this.state
         return ( 
             <ToastNotification
                 // Using key attribute as a workaround for problem: https://github.com/carbon-design-system/carbon/issues/4211
@@ -70,7 +84,7 @@ export default class Notification extends React.PureComponent {
                 className='kv--toaster-notification'
                 subtitle={subtitle}
                 timeout={notificationTimeout}
-                title={msgs.get('toaster.action.success')}
+                title={title}
             />
         )
     }

--- a/src-web/components/kappnav/common/NotificationHandler.js
+++ b/src-web/components/kappnav/common/NotificationHandler.js
@@ -1,0 +1,86 @@
+/*****************************************************************
+*
+* Copyright 2019 IBM Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* 
+* http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*****************************************************************/
+
+// This handler will keep polling for new events and keep track of what should be shown
+// to the user
+
+import React from 'react'
+import moment from 'moment'
+
+const api_polling_intervals_milliseconds = 30000
+const localStore_key = 'timestamp-of-last-api-poll'
+
+export default class Notification extends React.PureComponent {
+    
+    constructor(props) {
+        super(props)
+    }
+    
+    render() {
+        return(<div id="notification-handler"></div>)
+    }
+    
+    componentDidMount() {
+        this.setLastAPICheckTime()
+
+        // Get last time we checked API and calculate
+        // when to check again
+        this.timer = setInterval(
+                () => this.getCompletedJobs(), 
+                api_polling_intervals_milliseconds);
+    }
+    
+    componentWillUnmount() {
+        // Save last time we checked the API
+        this.setLastAPICheckTime()
+
+        // Need to make sure interval is stopped when component
+        // is not being used
+        clearInterval(this.timer)
+    }
+
+    setLastAPICheckTime() {
+        const store = window.localStorage
+        const currentTime = moment()
+        store.setItem(localStore_key, currentTime)
+    }
+
+    getLastAPICheckTime() {
+        return windows.localStore.getItem(localStore_key)
+    }
+
+    getUnreadNotifications() {
+
+    }
+
+    getCompletedJobs() {
+        this.setLastAPICheckTime()
+
+        // API mandates `?time=` format to be yyyy-MM-dd'T'HH:mm:sss
+        const timeStampFromThirtySecondsAgo = 
+            this.getTimeStampFrom(30000).format('YYYY-MM-DDTHH:mm:sss')
+
+        fetch('/kappnav/resource/commands?time=' + timeStampFromThirtySecondsAgo)
+            .then(result => result.json())
+            .then(result => this.setState({ completed_commands: result }));
+    }
+
+    getTimeStampFrom(numMillisecondsAgo) {
+        return moment().subtract('milliseconds', numMillisecondsAgo);
+    }
+}

--- a/src-web/components/kappnav/common/NotificationHandler.js
+++ b/src-web/components/kappnav/common/NotificationHandler.js
@@ -21,66 +21,123 @@
 
 import React from 'react'
 import moment from 'moment'
+import Notification from './Notification'
 
-const api_polling_intervals_milliseconds = 30000
-const localStore_key = 'timestamp-of-last-api-poll'
+const api_polling_intervals_milliseconds = 30000 // ms
+const localStorage_key = 'timestamp-of-last-api-poll'
 
-export default class Notification extends React.PureComponent {
+export default class NotificationHandler extends React.PureComponent {
     
     constructor(props) {
         super(props)
+        this.state = {
+            completed_commands: []
+        }
     }
-    
+
     render() {
-        return(<div id="notification-handler"></div>)
+        const { completed_commands } = this.state
+        let renderResult = <div id="notification-handler"></div>
+        if(!completed_commands || completed_commands.length === 0) {
+            // return zero notifications, only return the handler
+            return renderResult
+        } else {
+            let commands = completed_commands.commands
+            renderResult =
+                <div id="notification-handler">
+                    {commands.map((command) => <Notification type='completed' result={command} />)}
+                </div>
+            return renderResult
+        }
     }
     
     componentDidMount() {
-        this.setLastAPICheckTime()
+        // Do initial fetch of completed jobs
+        this.getCompletedJobs()
 
-        // Get last time we checked API and calculate
-        // when to check again
+        // Setup the continuous API polling
         this.timer = setInterval(
                 () => this.getCompletedJobs(), 
                 api_polling_intervals_milliseconds);
     }
     
     componentWillUnmount() {
-        // Save last time we checked the API
-        this.setLastAPICheckTime()
-
         // Need to make sure interval is stopped when component
         // is not being used
         clearInterval(this.timer)
     }
 
+    /**
+     * Record the last timestamp the API was polled
+     */
     setLastAPICheckTime() {
         const store = window.localStorage
         const currentTime = moment()
-        store.setItem(localStore_key, currentTime)
+        store.setItem(localStorage_key, currentTime)
     }
 
+    /**
+     * Return the last timestamp the API was polled
+     */
     getLastAPICheckTime() {
-        return windows.localStore.getItem(localStore_key)
+        return window.localStorage.getItem(localStorage_key)
     }
 
-    getUnreadNotifications() {
-
-    }
-
+    /**
+     * Poll for completed jobs only if the last time polled has reached or exceeded 
+     * a set amount of time passed relative to current time.
+     */
     getCompletedJobs() {
-        this.setLastAPICheckTime()
+        if(! this.isItTimeToPollAPI()) {
+            // Too early to poll API, already polled recently
+            return
+        }
 
-        // API mandates `?time=` format to be yyyy-MM-dd'T'HH:mm:sss
+        // API mandates `?time=` format to be:
+        // yyyy-MM-dd'T'HH:mm:sss (without the ' around the T)
         const timeStampFromThirtySecondsAgo = 
-            this.getTimeStampFrom(30000).format('YYYY-MM-DDTHH:mm:sss')
+            this.getPastTimeStampFrom(api_polling_intervals_milliseconds).format('YYYY-MM-DDTHH:mm:ss')
 
         fetch('/kappnav/resource/commands?time=' + timeStampFromThirtySecondsAgo)
             .then(result => result.json())
-            .then(result => this.setState({ completed_commands: result }));
+            .then(result => this.processCompletedJobs(result))
     }
 
-    getTimeStampFrom(numMillisecondsAgo) {
+    /**
+     * Do what is needed to be done right after calling getting a successful response from
+     * polling the API for completed jobs
+     * @param {*} result - json response from API call
+     */
+    processCompletedJobs(result) {
+        this.setState({ completed_commands: result })
+        this.setLastAPICheckTime()
+    }
+
+    /**
+     * Helper method to do date calculation on whether the last timestamp
+     * the API was polled exceeds a certain threshold.  Essentially, the method
+     * enforces "We polled 30 seconds ago, don't poll" and "It's been 30 seconds or more
+     * seconds since we last polled".
+     */
+    isItTimeToPollAPI() {
+        let last_time_polled = this.getLastAPICheckTime()
+        if(! last_time_polled) {
+            // No history of past polling, assume we need to poll immedately
+            return true
+        }
+        last_time_polled = moment(last_time_polled) // convert to a moment object to do time malipulation
+        const next_polling_timestamp = last_time_polled.add('milliseconds', api_polling_intervals_milliseconds)
+        const current_timpstamp = moment()
+
+        // current time is past next scheduled polling, POLL API!
+        return current_timpstamp.isAfter(next_polling_timestamp) 
+    }
+
+    /**
+     * Method that calculates the timestamp from (current time - numMillisecondsAgo)
+     * @param {*} numMillisecondsAgo - How far back from current time in milliseconds
+     */
+    getPastTimeStampFrom(numMillisecondsAgo) {
         return moment().subtract('milliseconds', numMillisecondsAgo);
     }
 }

--- a/src-web/components/kappnav/modals/ActionMessageModal.js
+++ b/src-web/components/kappnav/modals/ActionMessageModal.js
@@ -81,7 +81,7 @@ class ActionMessageModal extends React.PureComponent {
       //  Toaster component to a different React class Component.
       if (open) {
         return (
-          <Notification result={result} handleClose={handleClose}/>
+          <Notification type='initiated' result={result} handleClose={handleClose}/>
         )
       }
       else {


### PR DESCRIPTION
Related to kappnav/issues#81

See commit messages for details

# Current limitation
This PR delivers the notification for completed jobs.  The limitation is that the notification cards are still on top of each other.  We will need to do additional work to allow for more than one notification displayed at once.

As it is current, the simplest demo works well.
1. Submit a job that completes in 5 seconds.
2. Observe the toaster notification indicating the job initiated
![image](https://user-images.githubusercontent.com/31117513/73870553-e90feb80-4811-11ea-8548-4db5bb6cd9fa.png)
3. Notification auto hides in 5 seconds
4. Wait 30 seconds
5. Observe a second toaster notification appears indicating the job completed
![image](https://user-images.githubusercontent.com/31117513/73870561-ee6d3600-4811-11ea-83e0-921fb0285b70.png)
6. Second notification auto hides in 5 seconds