### PR TITLE
fix(build): Downgrade carbon-addons-cloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-register": "^6.24.1",
     "babel-runtime": "6.26.0",
     "body-parser": "^1.17.2",
-    "carbon-addons-cloud": "3.x",
+    "carbon-addons-cloud": "3.5.1",
     "carbon-addons-cloud-react": "1.x",
     "carbon-components": "9.x",
     "carbon-components-react": "6.x",


### PR DESCRIPTION
Fixes kappnav/issues#118

- There is a build break with message:

File to import not found or unreadable:
carbon-components/scss/globals/scss/colors.