### PR TITLE
Modified search field size and inline message position

### DIFF
--- a/scss/table.scss
+++ b/scss/table.scss
@@ -166,13 +166,20 @@ tr.bx--expandable-row-v2 + tr[data-child-row] td {
 
 .justifyToolbarContent { //add space between toolbar items(search, InlineNotification, modal button) to evenly position them above the table
   justify-content: space-between;
+
+  .tableInlineNotification { //inline message is in bewteen the search and a button so margin is needed on both sides
+    margin-right: 2.5rem;
+  }
 }
 
 .bx--toolbar-content { //removing left margin that wasn't allowing justify-content to work
   margin-left: 0px;
 }
 
-.tableInlineNotification {
+.tableInlineNotification { //only add margin on left to add space between search and inline message - msg will float right
   margin-left: 2.5rem;
-  margin-right: 2.5rem;
+}
+
+.bx--search { //fix size of search field so it doesn't shrink
+  width: 250px;
 }


### PR DESCRIPTION
Issues:
- When there's an inline message that's too long, the search field is shrunk and too small. 
- Inline message was off centered above the table 

Fix:
- Gave the search field a fixed size 
- Removed right margin when in Components view and included the right margin in views where the inline message will be in between the search and another element in the toolbar 