### PR TITLE
Disable selectable rows in ResourceTable 

### DIFF
--- a/src-web/components/kappnav/ComponentView.jsx
+++ b/src-web/components/kappnav/ComponentView.jsx
@@ -144,7 +144,7 @@ class ComponentView extends Component {
             <div>
               {customComponentButtons && customComponentButtons.map((button, index) => (
                 <Button small icon={button.icon}
-                  onClick={button.action.bind(this)}
+                  onClick={button.action.bind(this, this.props.history, name, this.props.baseInfo.selectedNamespace)}
                   title={msgs.get(button.buttonDescription)}
                   iconDescription={msgs.get(button.iconDescription)}
                   id={'customComponentButtons' + index}>

--- a/src-web/components/kappnav/common/ResourceTable.js
+++ b/src-web/components/kappnav/common/ResourceTable.js
@@ -472,7 +472,7 @@ class ResourceTable extends Component {
 														return (
 															rows.map(row => (
 															<TableRow key={row.id}>
-															<TableSelectRow {...getSelectionProps({ row })} ariaLabel={row.id + '-checkbox'} disabled={false}/>
+															<TableSelectRow {...getSelectionProps({ row })} ariaLabel={row.id + '-checkbox'} checked={row.disabled} disabled={row.disabled}/>
 																{row.cells.map(cell => (
 																	this.renderCell(row, cell)
 																))}

--- a/src-web/components/kappnav/common/ResourceTable.js
+++ b/src-web/components/kappnav/common/ResourceTable.js
@@ -472,7 +472,7 @@ class ResourceTable extends Component {
 														return (
 															rows.map(row => (
 															<TableRow key={row.id}>
-															<TableSelectRow {...getSelectionProps({ row })} ariaLabel={row.id + '-checkbox'} checked={row.disabled} disabled={row.disabled}/>
+															{row.disabled ? <TableSelectRow {...getSelectionProps({ row })} ariaLabel={row.id + '-checkbox'} checked={row.disabled} disabled={row.disabled}/> : <TableSelectRow {...getSelectionProps({ row })} ariaLabel={row.id + '-checkbox'}/>}
 																{row.cells.map(cell => (
 																	this.renderCell(row, cell)
 																))}


### PR DESCRIPTION
- By comparing things saved in the redux store you can disable rows in a table that have had actions already been completed on them 
- Made changes to pass in `this.props.history` into the button action so that the action could use that instead of setting `window.location.href` which causes a page refresh and the loss of contents saved in redux store