### PR TITLE
Collections are now stacks

### DIFF
--- a/nls/kappnav.properties
+++ b/nls/kappnav.properties
@@ -230,10 +230,10 @@ action.url.deployment.projdoc.text= View Project Doc
 action.url.deployment.projdoc.desc= View project documentation.
 action.url.deployment.projcode.text= View Project Code
 action.url.deployment.projcode.desc= View project source code.
-action.url.deployment.kabcolldoc.text= View Collection Doc
-action.url.deployment.kabcolldoc.desc= View Kabanero Collection Documentation.
-action.url.deployment.kabcollcode.text= View Collection Code
-action.url.deployment.kabcollcode.desc= View Kabanero collection source code.
+action.url.deployment.kabcolldoc.text= View Stack Doc
+action.url.deployment.kabcolldoc.desc= View Kabanero stack documentation.
+action.url.deployment.kabcollcode.text= View Stack Code
+action.url.deployment.kabcollcode.desc= View Kabanero stack source code.
 
 action.url.deploymentconfig.detail.text= View Detail
 action.url.deploymentconfig.detail.desc= View DeploymentConfig detail


### PR DESCRIPTION
Appsody has changed terminology and what was "collections" are now "stacks". Corresponding labelling changes are needed in kAppNav.

For kappnav/issues#144