### PR TITLE
fix(a11y): Make timestamp readable by JAWS

### DIFF
--- a/scss/notification.scss
+++ b/scss/notification.scss
@@ -1,6 +1,6 @@
 /*****************************************************************
  *
- * Copyright 2019 IBM Corporation
+ * Copyright 2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scss/notification.scss
+++ b/scss/notification.scss
@@ -31,6 +31,7 @@
 }
 .bx--toast-notification__caption {
     font-size: 1rem;
+    display: inline;
 }
 
 .toast {

--- a/src-web/components/kappnav/common/Notification.js
+++ b/src-web/components/kappnav/common/Notification.js
@@ -28,7 +28,7 @@ const notificationTimeout = 5000 // ms, how long before auto hiding the notifica
 
 const _caption = 
     <div>
-        {new moment().format('HH:mm:ss   LL')}
+        <h3 className='bx--toast-notification__caption'>{new moment().format('HH:mm:ss   LL')}</h3>
         <a href={location.protocol + '//' + location.host + CONTEXT_PATH + '/jobs'}>
             <Icon className="launch-icon"
                 name='launch'

--- a/src-web/components/kappnav/common/Notification.js
+++ b/src-web/components/kappnav/common/Notification.js
@@ -1,6 +1,6 @@
 /*****************************************************************
  *
- * Copyright 2019 IBM Corporation
+ * Copyright 2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
JAWS (screen reader) was not reading the timestamp in the notification card.

![image](https://user-images.githubusercontent.com/31117513/75396778-f8d39a80-58ba-11ea-8fea-4abc05b27976.png)
