### PR TITLE
Added getting started assistance on command action page

### DIFF
--- a/nls/kappnav.properties
+++ b/nls/kappnav.properties
@@ -303,4 +303,4 @@ edit.207 = Unable to edit the resource because of a Kubernetes exception. The ex
 
 run.audit=Run Audit
 run.audit.action.description = Run Inventory Command Action
-table.empty.command.actions = No actions have been submitted yet. Want to 
+table.empty.command.actions = No actions have been submitted yet. Want to run the audit action?

--- a/nls/kappnav.properties
+++ b/nls/kappnav.properties
@@ -303,3 +303,4 @@ edit.207 = Unable to edit the resource because of a Kubernetes exception. The ex
 
 run.audit=Run Audit
 run.audit.action.description = Run Inventory Command Action
+table.empty.command.actions = No actions have been submitted yet. Want to 

--- a/src-web/components/kappnav/JobView.jsx
+++ b/src-web/components/kappnav/JobView.jsx
@@ -56,7 +56,9 @@ class JobView extends Component {
         {key: 'component', header: msgs.get('table.header.component'), type: SEARCH_HEADER_TYPES.STRING},
         {key: 'age', header: msgs.get('table.header.age'), type: SEARCH_HEADER_TYPES.STRING},
         {key: 'menuAction', header: msgs.get('table.header.action'), type: SEARCH_HEADER_TYPES.NOT_SEARCHABLE}
-      ]
+      ],
+      viewType: 'table.empty.command.actions',
+      modalType: 'run.audit'
     }
 
     // make 'this' visible to class methods
@@ -96,12 +98,14 @@ class JobView extends Component {
               createNewModal={() => {
                 return (
                   <div>
-                    <Button small iconDescription={msgs.get('run.audit')} onClick={() => openActionModal(document.documentElement.getAttribute('appnavConfigmapNamespace'), 'kappnav', 'app-nav-inventory', msgs.get('run.audit.action.description'))}>
+                    <Button small iconDescription={msgs.get('run.audit')} id={`page-action`} onClick={() => openActionModal(document.documentElement.getAttribute('appnavConfigmapNamespace'), 'kappnav', 'app-nav-inventory', msgs.get('run.audit.action.description'))}>
                       {msgs.get('run.audit')}
                     </Button>
                   </div>
                 )
               }}
+              viewType={this.state.viewType}
+              modalType={this.state.modalType}
             />
           </div>
         </div>

--- a/src-web/components/kappnav/JobView.jsx
+++ b/src-web/components/kappnav/JobView.jsx
@@ -19,7 +19,7 @@
 import 'carbon-components/scss/globals/scss/styles.scss'
 import React, {Component} from 'react'
 import { connect } from 'react-redux'
-import {Loading, Button} from 'carbon-components-react'
+import {Loading, Button, DataTable} from 'carbon-components-react'
 import {CONTEXT_PATH, PAGE_SIZES, SORT_DIRECTION_ASCENDING, RESOURCE_TYPES, STATUS_COLORS, CONFIG_CONSTANTS} from '../../actions/constants'
 import {getRowSlice, sort, sortColumn, getOverflowMenu, buildStatusHtml, getAge, getAgeDifference, getCreationTime, performUrlAction} from '../../actions/common'
 import msgs from '../../../nls/kappnav.properties'
@@ -30,6 +30,11 @@ import {getSearchableCellList, SEARCH_HEADER_TYPES} from './common/ResourceTable
 import { getToken, openActionModal } from '../../actions/common'
 
 const jobResourceData = getResourceData(RESOURCE_TYPES.JOB)
+
+const {
+  TableCell,
+  TableRow
+} = DataTable;
 
 // This is the view that shows a collection of Command Actions jobs
 class JobView extends Component {
@@ -58,7 +63,6 @@ class JobView extends Component {
         {key: 'menuAction', header: msgs.get('table.header.action'), type: SEARCH_HEADER_TYPES.NOT_SEARCHABLE}
       ],
       viewType: 'table.empty.command.actions',
-      modalType: 'run.audit'
     }
 
     // make 'this' visible to class methods
@@ -105,7 +109,7 @@ class JobView extends Component {
                 )
               }}
               viewType={this.state.viewType}
-              modalType={this.state.modalType}
+              getCustomTableMsg={this.createMessageForEmptyTable}
             />
           </div>
         </div>
@@ -338,6 +342,15 @@ class JobView extends Component {
       })
       this.filterTable(search, this.state.pageNumber, this.state.pageSize, rowArray)
     })
+  }
+
+  createMessageForEmptyTable(headers) {
+    var originalMsg = msgs.get('table.empty.command.actions')
+    var auditLinkTxt = msgs.get('audit.link.text')
+    var removeAuditText = originalMsg.split(auditLinkTxt)
+    var part1 = removeAuditText[0] //text before 'audit'
+    var part2 = removeAuditText[1] //text after 'audit'
+    return <TableRow><TableCell colSpan={headers.length + 1} aria-label={originalMsg}>{part1}<a className='emptyTableResourceLink' id='navModalLink' tabIndex='0' aria-label={msgs.get('run.audit')}>{auditLinkTxt}</a>{part2}</TableCell></TableRow>
   }
 } // end of JobView component
 

--- a/src-web/components/kappnav/common/ResourceTable.js
+++ b/src-web/components/kappnav/common/ResourceTable.js
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,7 @@ const {
 
 const translateWithId = (locale, id) => msgs.get(id)
 
-var displayedHeaders; //used to calculate how many columns the message for an empty table(w/ non-selectable rows) should span 
+var displayedHeaders; //used to calculate how many columns the message for an empty table(w/ non-selectable rows) should span
 
 export const SEARCH_HEADER_TYPES= {
 	NOT_SEARCHABLE : 'NOT_SEARCHABLE',
@@ -134,7 +134,7 @@ class ResourceTable extends Component {
 	}
 
 	/* This function is hidding the expandable icon from the DataTable Carbon Components only for
-	   those resources which doesn't have the "section-map" attribute or if the "section-map" 
+	   those resources which doesn't have the "section-map" attribute or if the "section-map"
 	   attribute is empty*/
 	componentDidMount() {
 		this.connectAddLinkOnClick()
@@ -156,7 +156,7 @@ class ResourceTable extends Component {
 	}
 
 	/* This function is hidding the expandable icon from the DataTable Carbon Components only for
-	   those resources which doesn't have the "section-map" attribute or if the "section-map" 
+	   those resources which doesn't have the "section-map" attribute or if the "section-map"
 	   attribute is empty by first making expandable icon visible on every rows of the DataTable*/
 	componentDidUpdate() {
 		this.connectAddLinkOnClick()
@@ -367,9 +367,9 @@ class ResourceTable extends Component {
 	//button object contains key:value pairs specifying button properties(ex: kind, text, etc)
 	renderButton(button, selectedRows) {
 		let b;
-		if (button.href) { 
+		if (button.href) {
 			b = <Button small kind={button.kind} id={button.buttonText} href={button.href} aria-label={button.buttonText}>{button.buttonText}</Button>
-		} 
+		}
 		if (button.action) { //onClick method call passes selectedRows to perform 'action' on/with those values
 			b = <Button small kind={button.kind} id={button.buttonText} aria-label={button.buttonText} onClick={() => {button.action(selectedRows)}}>{button.buttonText}</Button>
 		}
@@ -528,24 +528,20 @@ class ResourceTable extends Component {
 															}
 														})
 													})()}
-		
+
 												</TableRow>
 											</TableHead>
 											<TableBody>
 											{(() => {
-												//When the resource table is empty, add a new row with a message that encourages users to add a new resource 
-												//viewType is undefined when in the Command Actions view
-												//viewType is the message key for the resource type: applications, WAS ND cells, or Liberty collectives
+												//When the resource table is empty, add a new row with a message that encourages users to add a new resource
+												//modalType is undefined when in the Command Actions view
+												//viewType is the message key for the view: applications, WAS ND cells, Liberty collectives, command actions
 												//modal is the message key for the title of the add modal that should pop up (ex: "Add Application")
 													if (rows.length === 0 && viewType) {
-														var modal = msgs.get(modalType);													
-	
-														if(viewType === 'table.empty.command.actions') { //the message is different for command actions
-															var msg = msgs.get(viewType);
-															return (
-																<TableRow><TableCell colSpan={displayedHeaders + 1}>{msg} <span className='emptyTableResourceLink' id='navModalLink' tabIndex='0' role='button' aria-label={msg+' '+modal}>{modal}</span>?</TableCell></TableRow>
-															)
+														if(viewType === 'table.empty.command.actions') { //need a custom message for empty table in Command Actions view
+															return (this.props.getCustomTableMsg(headers))
 														} else {
+															var modal = msgs.get(modalType);
 															var resource = msgs.get(viewType);
 															var msg = msgs.get('table.empty', [resource]);
 															return (

--- a/src-web/components/kappnav/common/ResourceTable.js
+++ b/src-web/components/kappnav/common/ResourceTable.js
@@ -1,6 +1,6 @@
 /*****************************************************************
  *
- * Copyright 2019 IBM Corporation
+ * Copyright 2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ class ResourceTable extends Component {
 	When the resource table is empty, a row with text should have a link to the 'Add [resoure_name]' navmodal.
 	Clicking this link should trigger a click on the 'Add [resource_name]' button above the table */
 	connectAddLinkOnClick() {
-		var addResourceButton = document.getElementById('create-application');
+		var addResourceButton = document.getElementById('page-action');
 		var navModalLink = document.getElementById('navModalLink');
 		if (navModalLink && addResourceButton) {
 			navModalLink.onclick = function() {addResourceButton.click()};
@@ -537,15 +537,22 @@ class ResourceTable extends Component {
 												//viewType is undefined when in the Command Actions view
 												//viewType is the message key for the resource type: applications, WAS ND cells, or Liberty collectives
 												//modal is the message key for the title of the add modal that should pop up (ex: "Add Application")
-												if (rows.length === 0 && viewType) {
-													var resource = msgs.get(viewType);
-													var modal = msgs.get(modalType);
-													var msg = msgs.get('table.empty', [resource]);
-		
-													return (
-														<TableRow><TableCell colSpan={displayedHeaders + 1}>{msg} <span className='emptyTableResourceLink' id='navModalLink' tabindex='0' role='button' aria-label={msg+' '+modal}>{modal}</span>.</TableCell></TableRow>
-													)
-												} else {
+													if (rows.length === 0 && viewType) {
+														var modal = msgs.get(modalType);													
+	
+														if(viewType === 'table.empty.command.actions') { //the message is different for command actions
+															var msg = msgs.get(viewType);
+															return (
+																<TableRow><TableCell colSpan={displayedHeaders + 1}>{msg} <span className='emptyTableResourceLink' id='navModalLink' tabIndex='0' role='button' aria-label={msg+' '+modal}>{modal}</span>?</TableCell></TableRow>
+															)
+														} else {
+															var resource = msgs.get(viewType);
+															var msg = msgs.get('table.empty', [resource]);
+															return (
+																<TableRow><TableCell colSpan={displayedHeaders + 1}>{msg} <span className='emptyTableResourceLink' id='navModalLink' tabIndex='0' role='button' aria-label={msg+' '+modal}>{modal}</span>.</TableCell></TableRow>
+															)
+														}
+													} else {
 													return(
 														rows.map(row => (
 														<React.Fragment key={row.id}>

--- a/src-web/components/kappnav/modals/NavModal.js
+++ b/src-web/components/kappnav/modals/NavModal.js
@@ -1,6 +1,6 @@
 /*****************************************************************
  *
- * Copyright 2019 IBM Corporation
+ * Copyright 2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ class NavModal extends React.PureComponent {
     const {open, jsonMode, selectedMenuItem, parsingError, validationErrors} = this.state
 
     return (<div>
-      <Button small icon={'add--glyph'} onClick={this.handleOpen.bind(this, true)} disabled={this.props.disabled} iconDescription={msgs.get('svg.description.plus')} id={`create-application`}>
+      <Button small icon={'add--glyph'} onClick={this.handleOpen.bind(this, true)} disabled={this.props.disabled} iconDescription={msgs.get('svg.description.plus')} id={`page-action`}>
         {this.props.buttonName}
       </Button>
       {


### PR DESCRIPTION
Issue: https://github.com/kappnav/issues/issues/148

Changes made:
* Added new message for the empty commands action table
* Modified ResourceTable and JobView to use the same logic as the other views that display a message with and action when the table is empty

**Note: This is the first iteration of the getting started assistance changes. I did not include a dropdown since the inventory action is the only global action we have at the moment.** 

![image](https://user-images.githubusercontent.com/6720263/76874864-c70c7e80-683d-11ea-98f2-9ce5842a1f48.png)
