### PR TITLE
Added missing message for command action view

### DIFF
--- a/nls/kappnav.properties
+++ b/nls/kappnav.properties
@@ -304,3 +304,4 @@ edit.207 = Unable to edit the resource because of a Kubernetes exception. The ex
 run.audit=Run Audit
 run.audit.action.description = Run Inventory Command Action
 table.empty.command.actions = No actions have been submitted yet. Want to run the audit action?
+audit.link.text = audit


### PR DESCRIPTION
I added the message I forgot to add before that's used in the logic to display a message in an empty command actions table. 