### PR TITLE
Add apiVersion query parameter to API calls with KIND in path

### DIFF
--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -236,10 +236,14 @@ const openModal_internal = (operation, resource, application, applicationNamespa
   }
 }
 
-export const performUrlAction = (urlPattern, openWindow, kind, name, namespace, linkId, followLink) => {
+export const performUrlAction = (urlPattern, openWindow, kind, name, namespace, linkId, followLink, apiVersion) => {
   if(urlPattern) {
+
+    let apiVersionQueryParam = apiVersion ? '&apiVersion='+apiVersion : ''
+    apiVersionQueryParam = encodeURIComponent(apiVersionQueryParam)
+
     //expand the url
-    fetch('/kappnav/resource/' + encodeURIComponent(name)+'/'+kind+'?action-pattern='+encodeURIComponent(urlPattern)+'&namespace='+encodeURIComponent(namespace))
+    fetch('/kappnav/resource/' + encodeURIComponent(name)+'/'+kind+'?action-pattern='+encodeURIComponent(urlPattern)+'&namespace='+encodeURIComponent(namespace)+apiVersionQueryParam)
       .then(response => {
         if (!response.ok) {
         //Failed to get a link back
@@ -457,6 +461,8 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
   var itemId = cloneData.metadata.uid
   const resourceLabels = cloneData.metadata.labels
   const resourceAnnotations = cloneData.metadata.annotations
+  const apiVersion = cloneData['apiVersion']
+  
 
   //remove fields that should not show up on an editor
   delete cloneData.metadata.creationTimestamp
@@ -492,9 +498,9 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
           const namespace = componentData && componentData.metadata && componentData.metadata.namespace
           const name = componentData && componentData.metadata && componentData.metadata.name
           const componentBodyToRemove =[{
-            "app":name,
+            "app": name,
             "namespace": namespace,
-            "kind":kind
+            "kind": kind
           }]
           return customAction.getCustomAction(staticindex, itemId, applicationName, applicationNamespace, componentBodyToRemove)
         }
@@ -516,7 +522,7 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
       const kind = componentData && componentData.kind
       const namespace = componentData && componentData.metadata && componentData.metadata.namespace
       const name = componentData && componentData.metadata && componentData.metadata.name
-      performUrlAction(action['url-pattern'], action['open-window'], kind, name, namespace, undefined, false)
+      performUrlAction(action['url-pattern'], action['open-window'], kind, name, namespace, undefined, false, apiVersion)
     })
 
     urlActions = urlActions.map((action, urlindex) => {
@@ -525,7 +531,7 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
       return <OverflowMenuItem key={action.name}
         primaryFocus={urlindex === 0 && !hasStaticActions}
         itemText={actionLabel}
-        onClick={performUrlAction.bind(this, action['url-pattern'], action['open-window'], componentData && componentData.kind, componentData && componentData.metadata && componentData.metadata.name, componentData && componentData.metadata && componentData.metadata.namespace, undefined, true)}
+        onClick={performUrlAction.bind(this, action['url-pattern'], action['open-window'], componentData && componentData.kind, componentData && componentData.metadata && componentData.metadata.name, componentData && componentData.metadata && componentData.metadata.namespace, undefined, true, apiVersion)}
         onFocus={(e) => {
           if(actionDesc){ e.target.title = actionDesc }
         }}

--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -466,7 +466,7 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
   // ***************
   // Static Actions
 
-  var hasStaticActions = staticResourceData && staticResourceData.actions && staticResourceData.actions.length>0
+  const hasStaticActions = staticResourceData && staticResourceData.actions && staticResourceData.actions.length>0
   let staticActions = []
   if(hasStaticActions) {
     staticActions =
@@ -482,16 +482,16 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
 
   // ***************
   // Custom Actions
-  var hasCustomActions = staticResourceData && staticResourceData.customActions && staticResourceData.customActions.length>0
+  const hasCustomActions = staticResourceData && staticResourceData.customActions && staticResourceData.customActions.length>0
   let customActions = []
   if(hasCustomActions) {
     customActions =
       staticResourceData.customActions.map((customAction, staticindex) => {
         if(customAction.show(componentData, actionMap, staticResourceData, applicationName, applicationNamespace)){
-          var kind = componentData && componentData.kind
-          var namespace = componentData && componentData.metadata && componentData.metadata.namespace
-          var name = componentData && componentData.metadata && componentData.metadata.name
-          var componentBodyToRemove =[{
+          const kind = componentData && componentData.kind
+          const namespace = componentData && componentData.metadata && componentData.metadata.namespace
+          const name = componentData && componentData.metadata && componentData.metadata.name
+          const componentBodyToRemove =[{
             "app":name,
             "namespace": namespace,
             "kind":kind
@@ -504,18 +504,18 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
   // ***************
   // URL Actions
 
-  var urlActions = actionMap && actionMap[CONFIG_CONSTANTS.URL_ACTIONS]
+  let urlActions = actionMap && actionMap[CONFIG_CONSTANTS.URL_ACTIONS]
   urlActions = urlActions && urlActions.filter((action) => {
     return !action[CONFIG_CONSTANTS.MENU_ITEM] || action[CONFIG_CONSTANTS.MENU_ITEM]!='false'
   })
-  var hasUrlActions = urlActions && urlActions.length && urlActions.length>0
+  const hasUrlActions = urlActions && urlActions.length && urlActions.length>0
   if(hasUrlActions) {
     urlActions = removeDisabledActions(resourceLabels, resourceAnnotations, urlActions)
 
     urlActions.forEach((action) => { //try to cache the links ahead of time
-      var kind = componentData && componentData.kind
-      var namespace = componentData && componentData.metadata && componentData.metadata.namespace
-      var name = componentData && componentData.metadata && componentData.metadata.name
+      const kind = componentData && componentData.kind
+      const namespace = componentData && componentData.metadata && componentData.metadata.namespace
+      const name = componentData && componentData.metadata && componentData.metadata.name
       performUrlAction(action['url-pattern'], action['open-window'], kind, name, namespace, undefined, false)
     })
 
@@ -538,9 +538,9 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
   // ***************
   // Command Actions
 
-  var cmdActions = actionMap && actionMap[CONFIG_CONSTANTS.CMD_ACTIONS]
-  var cmdInputs = actionMap && actionMap[CONFIG_CONSTANTS.INPUTS]
-  var hasCmdActions = cmdActions && cmdActions.length && cmdActions.length>0
+  let cmdActions = actionMap && actionMap[CONFIG_CONSTANTS.CMD_ACTIONS]
+  const cmdInputs = actionMap && actionMap[CONFIG_CONSTANTS.INPUTS]
+  const hasCmdActions = cmdActions && cmdActions.length && cmdActions.length>0
   if(hasCmdActions) {
     cmdActions = removeDisabledActions(resourceLabels, resourceAnnotations, cmdActions)
 
@@ -566,7 +566,7 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
   // Use filter to remove undefined/null lists that were added by .concat()
   allEnabledActions = allEnabledActions.filter(n => n)
   if(allEnabledActions.length > 0) {
-    var menu =
+    const menu =
       <OverflowMenu floatingMenu flipped iconDescription={msgs.get('svg.description.overflowMenu')}>
         {allEnabledActions}
       </OverflowMenu>

--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -214,9 +214,12 @@ const openModal_internal = (operation, resource, application, applicationNamespa
       heading: 'modal.'+operation+'.heading'
     }, resource,  '/kappnav/'+resourceType+'/'+encodeURIComponent(resource.metadata.name)+'?namespace='+encodeURIComponent(resource.metadata.namespace))
   } else if(operation === 'action') {
-    var url = '/kappnav/resource/' + encodeURIComponent(resource.metadata.name)+'/'+resource.kind+'/execute/command/'+encodeURIComponent(cmd.name)+'?namespace='+encodeURIComponent(resource.metadata.namespace)
+    const apiVersion = resource['apiVersion']
+    let url = '/kappnav/resource/' + encodeURIComponent(resource.metadata.name)+'/'+resource.kind+'/execute/command/'+encodeURIComponent(cmd.name)
+              +'?namespace='+encodeURIComponent(resource.metadata.namespace)+'&apiVersion='+apiVersion
     if(application) {
-      url = '/kappnav/resource/' + encodeURIComponent(application)+'/' + encodeURIComponent(resource.metadata.name)+'/'+resource.kind+'/execute/command/'+encodeURIComponent(cmd.name)+'?namespace='+encodeURIComponent(resource.metadata.namespace)+'&application-namespace='+applicationNamespace
+      url = '/kappnav/resource/' + encodeURIComponent(application)+'/' + encodeURIComponent(resource.metadata.name)+'/'+resource.kind+'/execute/command/'+encodeURIComponent(cmd.name)
+            +'?namespace='+encodeURIComponent(resource.metadata.namespace)+'&application-namespace='+applicationNamespace+'&apiVersion='+apiVersion
     }
 
     var input = undefined
@@ -239,8 +242,7 @@ const openModal_internal = (operation, resource, application, applicationNamespa
 export const performUrlAction = (urlPattern, openWindow, kind, name, namespace, linkId, followLink, apiVersion) => {
   if(urlPattern) {
 
-    let apiVersionQueryParam = apiVersion ? '&apiVersion='+apiVersion : ''
-    apiVersionQueryParam = encodeURIComponent(apiVersionQueryParam)
+    const apiVersionQueryParam = apiVersion ? '&apiVersion='+encodeURIComponent(apiVersion) : ''
 
     //expand the url
     fetch('/kappnav/resource/' + encodeURIComponent(name)+'/'+kind+'?action-pattern='+encodeURIComponent(urlPattern)+'&namespace='+encodeURIComponent(namespace)+apiVersionQueryParam)
@@ -528,6 +530,7 @@ export const getOverflowMenu = (componentData, actionMap, staticResourceData, ap
     urlActions = urlActions.map((action, urlindex) => {
       let actionLabel = action['text.nls'] ? msgs.get(action['text.nls']) : action.text
       let actionDesc = action['description.nls'] ? msgs.get(action['description.nls']) : action.description
+      const apiVersion = componentData['apiVersion']
       return <OverflowMenuItem key={action.name}
         primaryFocus={urlindex === 0 && !hasStaticActions}
         itemText={actionLabel}

--- a/src-web/components/kappnav/DetailView.jsx
+++ b/src-web/components/kappnav/DetailView.jsx
@@ -127,7 +127,7 @@ class DetailView extends Component {
           this.setState({ loading: false, data: result })
 
           //fetch the action maps
-          fetch(('/kappnav/resource/' + encodeURIComponent(result.metadata.name) + '/' + result.kind + '/actions?namespace=' + encodeURIComponent(result.metadata.namespace)))
+          fetch(('/kappnav/resource/' + encodeURIComponent(result.metadata.name) + '/' + result.kind + '/actions?namespace=' + encodeURIComponent(result.metadata.namespace) + '&apiVersion=' + encodeURIComponent(result['apiVersion'])))
             .then(response => {
               if (!response.ok) {
                 //no error here because it just means that the action maps will not be populated

--- a/src-web/components/kappnav/JobView.jsx
+++ b/src-web/components/kappnav/JobView.jsx
@@ -306,8 +306,19 @@ class JobView extends Component {
           const detailAction = urlActions[0]
           const kind = 'Job'
           const linkId = kind+'_'+metadata.name+'link'
-          itemObj.actionName = <a rel="noreferrer" id={linkId} href='#' onClick={performUrlAction.bind(this, detailAction['url-pattern'], detailAction['open-window'], kind, appUuid, metadata.namespace, undefined, true)}>{jobName}</a>
-          performUrlAction(detailAction['url-pattern'], detailAction['open-window'], kind, appUuid, metadata.namespace, linkId, false)  //update the link in place
+          
+          // apiVersion was not avaliable in the job information, but the rule for needing apiVersion is
+          // when the API call uses a Kubernetes kind in the path.  In this case, Job is the kind being
+          // called in performUrlAction().
+          const apiVersion = job['apiVersion']
+
+          itemObj.actionName =
+            <a rel="noreferrer"
+              id={linkId} href='#'
+              onClick={performUrlAction.bind(this, detailAction['url-pattern'], detailAction['open-window'], kind, appUuid, metadata.namespace, undefined, true, apiVersion)}>
+                {jobName}
+            </a>
+          performUrlAction(detailAction['url-pattern'], detailAction['open-window'], kind, appUuid, metadata.namespace, linkId, false, apiVersion)  //update the link in place
         } else {
           // Not every K8 platform has a URL for displaying K8 Job kind details
           itemObj.actionName = jobName

--- a/src-web/definitions/application.js
+++ b/src-web/definitions/application.js
@@ -404,6 +404,7 @@ export function refreshApplicationComponents(appname, namespace, appNavConfigDat
 
         itemObj.compositeKind = compositeKind;
         itemObj.kind = kind;
+        itemObj.apiVersion = component['apiVersion'];
         itemObj.namespace = component.metadata.namespace;
         itemObj.platform = platform;
         if(item.hasOwnProperty("section-map")){

--- a/src-web/definitions/application.js
+++ b/src-web/definitions/application.js
@@ -439,10 +439,11 @@ export function refreshApplicationComponents(appname, namespace, appNavConfigDat
           if(link) {
             //Expand the link and modify the URL on the fly to match the expanded link
             var linkId = kind+"_"+metadata.name+"link";
-            itemObj.name=<a id={linkId} href="#" onClick={performUrlAction.bind(this, link, urlActions[0]["open-window"], kind, metadata.name, metadata.namespace, undefined, true)}>
-              {metadata.name}
-            </a>;
-            performUrlAction(link, urlActions[0]["open-window"], kind, metadata.name, metadata.namespace, linkId, false);  //update the link in place
+            itemObj.name = <a id={linkId} href="#" onClick={performUrlAction.bind(this, link, urlActions[0]["open-window"], kind, metadata.name, metadata.namespace, undefined, true)}>
+                            {metadata.name}
+                           </a>;
+            const apiVersion = component['apiVersion']
+            performUrlAction(link, urlActions[0]["open-window"], kind, metadata.name, metadata.namespace, linkId, false, apiVersion);  //update the link in place
           } else {
               itemObj.name = metadata.name;
           }


### PR DESCRIPTION
Depends on pull request https://github.com/kappnav/apis/pull/70
For issue https://github.com/kappnav/issues/issues/100

Add the `apiVersion` query parameter to any API calls that have a Kubernetes Kind in the URL path.  The value of `apiVersion` is URL encoded.  For example `apps/v1` will be `apps%2Fv1`.

The UI code will assume the API code will decode the value when processing the `@QueryParam` Java annotation.

## Manual testing
1.  Tested DetailView, JobView, ComponentView, ApplicationView
2.  Tested submitting a `cmd-actions`