### PR TITLE
Making the left bar clickable throughout its length

### DIFF
--- a/scss/left-nav.scss
+++ b/scss/left-nav.scss
@@ -1,6 +1,6 @@
 /*****************************************************************
  *
- * Copyright 2019 IBM Corporation
+ * Copyright 2020 IBM Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,13 +96,17 @@
     }
   }
 
+  .anchor-props {
+    display: inline-block;
+    padding-left: 56px;
+    padding-right: 40px;
+  }
+
   .left-nav-item {
     font-size: 1rem;
     height: 50px;
     vertical-align: middle;
     line-height: 50px;
-    padding-left: 56px;
-    padding-right: 40px;
     cursor: pointer;
     white-space: nowrap;
     overflow: hidden;

--- a/src-web/components/LeftNav.js
+++ b/src-web/components/LeftNav.js
@@ -50,15 +50,15 @@ class LeftNav extends React.Component {
         <li className="left-nav-item primary-nav-item">
           {/* Tried using the below, but was having some issues */}
           {/* <Link role='menuitem' to='/kappnav-ui/applications'>Applications</Link> */}
-          <a role='menuitem' href="/kappnav-ui/applications" title={msgs.get('page.applicationView.title')}>{msgs.get('page.applicationView.title')}</a>
+          <a role='menuitem' className = 'anchor-props' href="/kappnav-ui/applications" title={msgs.get('page.applicationView.title')}>{msgs.get('page.applicationView.title')}</a>
         </li>
         <li className="left-nav-item primary-nav-item">
-        <a role='menuitem' href="/kappnav-ui/jobs" title={msgs.get('page.jobsView.title')}>{msgs.get('page.jobsView.title')}</a>
+        <a role='menuitem' className = 'anchor-props' href="/kappnav-ui/jobs" title={msgs.get('page.jobsView.title')}>{msgs.get('page.jobsView.title')}</a>
         </li>
         {/* getting all extended routes if any */}
         {getExtendedRoutes().length > 0 ? getExtendedRoutes().map((route) => {
             return <li className="left-nav-item primary-nav-item">
-              <a role='menuitem' href={route.href} title={route.title}>{route.title}</a>
+              <a role='menuitem' className = 'anchor-props' href={route.href} title={route.title}>{route.title}</a>
             </li>
         }): null}
       </ul>


### PR DESCRIPTION
Making the left bar clickable throughout its length. Since the whole area is highlighted, one could click anywhere in the highlighted area to go to that page.