### PR TITLE
Fix mistake from copy and paste lines

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -33,7 +33,6 @@
     <meta charset="UTF-8">
     <link rel='stylesheet' href='<%= manifest.common.css %>'>
     <link rel='stylesheet' href='<%= manifest.main.css %>'>
-    <link rel='icon' href='<%= manifest.main.css %>'>
     <link rel='icon' href="<%= contextPath %>/graphics/KAppNavLogo_1x.png">
   </head>
 


### PR DESCRIPTION
Related to kappnav/issues#197

Accidentally introduced an unnecessary line in the new EJS template.  Remove it.