### PR TITLE
Check for null/empty command map

### DIFF
--- a/src-web/components/kappnav/common/NotificationHandler.js
+++ b/src-web/components/kappnav/common/NotificationHandler.js
@@ -61,7 +61,7 @@ class NotificationHandler extends React.PureComponent {
     render() {
         const { completed_commands } = this.state
         let renderResult = <div id="notification-handler"></div>
-        if(!completed_commands || completed_commands.length === 0) {
+        if(!completed_commands || !completed_commands.commands || completed_commands.commands.length === 0) {
             // return zero notifications, only return the handler
             return renderResult
         } else {


### PR DESCRIPTION
To fix this issue found by A11y and GVT test:
![image](https://user-images.githubusercontent.com/29546393/84069034-82513900-a98f-11ea-8a57-08773481deba.png)
