### PR TITLE
Force assests-webpack-plugin to 3.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extends": "react-app"
   },
   "dependencies": {
-    "assets-webpack-plugin": "^3.9.6",
+    "assets-webpack-plugin": "3.9.x",
     "axios": "^0.19.2",
     "babel-core": "^6.26.0",
     "babel-plugin-dynamic-import-node": "^1.0.2",


### PR DESCRIPTION
Fixes this build break:

/app/node_modules/camelcase/index.js:69
                .replace(/[_.\- ]+([\p{Alpha}\p{N}_]|$)/gu, (_, p1) => p1.toLocaleUpperCase())
                ^

SyntaxError: Invalid regular expression: /[_.\- ]+([\p{Alpha}\p{N}_]|$)/: Invalid escape
    at camelCase (/app/node_modules/camelcase/index.js:69:3)
    at getAssetKind (/app/node_modules/assets-webpack-plugin/dist/lib/getAssetKind.js:9:10)
    at /app/node_modules/assets-webpack-plugin/dist/index.js:93:26
