### PR TITLE
Prevent failure in isActionEnabled() common method

### DIFF
--- a/src-web/actions/common.js
+++ b/src-web/actions/common.js
@@ -430,7 +430,12 @@ function isActionEnabled(resourceLabels, resourceAnnotations, action) {
     return true;
   }
 
-  let isEnabled = resourceLabels[enablementLabel];
+  let isEnabled = null;
+
+  if (enablementLabel) { //prevent failure when enablementLabel is undefined
+    isEnabled = resourceLabels[enablementLabel];
+  }
+
   if (isEnabled) {
     // The action's enablement-label has value X and
     // the resource has a label of X.  This means the
@@ -438,7 +443,10 @@ function isActionEnabled(resourceLabels, resourceAnnotations, action) {
     return true;
   }
 
-  isEnabled = resourceAnnotations[enablementAnnotation];
+  if (enablementAnnotation) { //prevent failure when enablementAnnotation is undefined
+    isEnabled = resourceAnnotations[enablementAnnotation];
+  }
+
   if (isEnabled) {
     // The action's enablement-annotation has value X and
     // the resource has a annotation of X.  This means the


### PR DESCRIPTION
**Issue:** I noticed that the UI hung due to a failure in the `isActionEnabled()` method when `enablementLabel` is undefined. Since `isEnabled` is set using `isEnabled = resourceLabels[enablementLabel];` the undefined `enableLabel` causes a failure. 

**Fix:** I added checks to make sure `isEnabled` is defined before it is set.